### PR TITLE
fix(powershell): replace all Unicode with ASCII for Windows PS 5.1 co…

### DIFF
--- a/install-unified.ps1
+++ b/install-unified.ps1
@@ -22,10 +22,10 @@ function Write-ColorOutput {
 }
 
 # Banner
-Write-ColorOutput "╔═══════════════════════════════════════════════════════════╗" "Cyan"
-Write-ColorOutput "║     SkillFoundry Framework - One-Click Installer             ║" "Cyan"
-Write-ColorOutput "║     Multi-Platform AI Agent & Skills Framework           ║" "Cyan"
-Write-ColorOutput "╚═══════════════════════════════════════════════════════════╝" "Cyan"
+Write-ColorOutput "+===========================================================+" "Cyan"
+Write-ColorOutput "|     SkillFoundry Framework - One-Click Installer             |" "Cyan"
+Write-ColorOutput "|     Multi-Platform AI Agent & Skills Framework           |" "Cyan"
+Write-ColorOutput "+===========================================================+" "Cyan"
 Write-Host ""
 
 # Detect platform (Claude Code, Copilot CLI, Cursor)
@@ -35,7 +35,7 @@ function Detect-Platform {
     # Check for Claude Code
     if (Get-Command claude -ErrorAction SilentlyContinue) {
         $platform = "claude"
-        Write-ColorOutput "✓ Detected: Claude Code" "Green"
+        Write-ColorOutput "[OK] Detected: Claude Code" "Green"
     }
     
     # Check for GitHub Copilot CLI
@@ -43,9 +43,9 @@ function Detect-Platform {
         (Get-Command copilot -ErrorAction SilentlyContinue)) {
         if ([string]::IsNullOrWhiteSpace($platform)) {
             $platform = "copilot"
-            Write-ColorOutput "✓ Detected: GitHub Copilot CLI" "Green"
+            Write-ColorOutput "[OK] Detected: GitHub Copilot CLI" "Green"
         } else {
-            Write-ColorOutput "⚠ Also detected: GitHub Copilot CLI" "Yellow"
+            Write-ColorOutput "[!] Also detected: GitHub Copilot CLI" "Yellow"
         }
     }
     
@@ -67,9 +67,9 @@ function Detect-Platform {
     if ($cursorFound -or (Get-Command cursor -ErrorAction SilentlyContinue)) {
         if ([string]::IsNullOrWhiteSpace($platform)) {
             $platform = "cursor"
-            Write-ColorOutput "✓ Detected: Cursor" "Green"
+            Write-ColorOutput "[OK] Detected: Cursor" "Green"
         } else {
-            Write-ColorOutput "⚠ Also detected: Cursor" "Yellow"
+            Write-ColorOutput "[!] Also detected: Cursor" "Yellow"
         }
     }
     
@@ -122,10 +122,10 @@ function Get-TargetDirectory {
     }
     
     if ($isProject) {
-        Write-ColorOutput "✓ Detected project directory: $(Split-Path $target -Leaf)" "Green"
+        Write-ColorOutput "[OK] Detected project directory: $(Split-Path $target -Leaf)" "Green"
         return $target
     } else {
-        Write-ColorOutput "⚠ Not in a project directory. Install to current directory?" "Yellow"
+        Write-ColorOutput "[!] Not in a project directory. Install to current directory?" "Yellow"
         $response = Read-Host "Continue? (y/N)"
         if ($response -notmatch "^[Yy]$") {
             $target = Read-Host "Enter project directory path"
@@ -138,12 +138,12 @@ function Get-TargetDirectory {
 # Main installation flow
 function Main {
     Write-ColorOutput "Step 1: Detecting environment..." "Blue"
-    Write-ColorOutput "✓ OS: Windows" "Green"
+    Write-ColorOutput "[OK] OS: Windows" "Green"
     
     $platform = Detect-Platform
     
     if ([string]::IsNullOrWhiteSpace($platform)) {
-        Write-ColorOutput "⚠ No AI platform detected automatically." "Yellow"
+        Write-ColorOutput "[!] No AI platform detected automatically." "Yellow"
         Write-Host ""
         Write-Host "Please select your platform:"
         Write-Host "  1) Claude Code"
@@ -161,7 +161,7 @@ function Main {
             }
         }
     } else {
-        Write-ColorOutput "✓ Platform: $platform" "Green"
+        Write-ColorOutput "[OK] Platform: $platform" "Green"
         Write-Host ""
         Write-Host "Use detected platform '$platform'? (Y/n)"
         $response = Read-Host "Press Enter to continue or 'n' to choose manually"
@@ -187,20 +187,20 @@ function Main {
     Write-Host ""
     Write-ColorOutput "Step 2: Locating framework..." "Blue"
     $frameworkDir = Get-FrameworkLocation
-    Write-ColorOutput "✓ Framework: $frameworkDir" "Green"
+    Write-ColorOutput "[OK] Framework: $frameworkDir" "Green"
     
     Write-Host ""
     Write-ColorOutput "Step 3: Selecting target project..." "Blue"
     $targetDir = Get-TargetDirectory
-    Write-ColorOutput "✓ Target: $targetDir" "Green"
+    Write-ColorOutput "[OK] Target: $targetDir" "Green"
     
     Write-Host ""
     Write-ColorOutput "Installation Summary:" "Cyan"
-    Write-Host "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+    Write-Host "===================================================="
     Write-Host "  Platform: $platform"
     Write-Host "  Framework: $frameworkDir"
     Write-Host "  Target: $targetDir"
-    Write-Host "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+    Write-Host "===================================================="
     Write-Host ""
     
     if (-not $Silent) {
@@ -223,7 +223,7 @@ function Main {
     }
     
     Write-Host ""
-    Write-ColorOutput "✓ Installation Complete!" "Green"
+    Write-ColorOutput "[OK] Installation Complete!" "Green"
     Write-Host ""
     Write-Host "Next steps:"
     switch ($platform) {

--- a/install.ps1
+++ b/install.ps1
@@ -32,14 +32,14 @@ trap {
     $exitCode = $_.Exception.HResult
     if ($exitCode -eq 0) { $exitCode = 1 }
     
-    Write-ColorOutput "`n╔═══════════════════════════════════════════════════════════╗" "Red"
-    Write-ColorOutput "║                    ERROR OCCURRED                          ║" "Red"
-    Write-ColorOutput "╚═══════════════════════════════════════════════════════════╝" "Red"
+    Write-ColorOutput "`n+===========================================================+" "Red"
+    Write-ColorOutput "|                    ERROR OCCURRED                          |" "Red"
+    Write-ColorOutput "+===========================================================+" "Red"
     Write-ColorOutput "Error: Installation failed" "Red"
     Write-ColorOutput "  Reason: $($_.Exception.Message)" "Yellow"
     Write-ColorOutput "  Location: $($_.InvocationInfo.ScriptLineNumber)" "Yellow"
     
-    # Rollback if partial installation — but NEVER rollback the source framework itself
+    # Rollback if partial installation -- but NEVER rollback the source framework itself
     $resolvedTarget = if ($TargetDir) { (Resolve-Path $TargetDir -ErrorAction SilentlyContinue).Path } else { $null }
     if ($resolvedTarget -and $resolvedTarget -ne $ScriptDir -and (Test-Path $resolvedTarget)) {
         if ((Test-Path (Join-Path $resolvedTarget ".claude")) -or
@@ -219,7 +219,7 @@ function Show-WhatsNew {
 
     Write-Host ""
     Write-Host "  What's New in v$Ver" -ForegroundColor Cyan
-    Write-Host "  $(('─' * 40))" -ForegroundColor Cyan
+    Write-Host "  $(('-' * 40))" -ForegroundColor Cyan
 
     $inBlock = $false
     $lineCount = 0
@@ -231,7 +231,7 @@ function Show-WhatsNew {
         if ($inBlock) {
             if ($line -match '^## \[' -or $line -match '^---$') { break }
             if ($line -match '^### (.+)') {
-                $heading = $Matches[1] -replace ' —.*', ''
+                $heading = $Matches[1] -replace ' --.*', ''
                 Write-Host "    $heading" -ForegroundColor Yellow
             } elseif ($line -match '^- (.+)' -and $lineCount -lt 10) {
                 $bullet = $Matches[1]
@@ -259,10 +259,10 @@ if (Test-Path $TargetDir) {
 }
 
 Write-Host ""
-Write-Host "  ┌─────────────────────────────────────────────────────┐" -ForegroundColor Cyan
-Write-Host "  │  SkillFoundry Framework — Installer                    │" -ForegroundColor Cyan
-Write-Host "  │  v$FrameworkVersion · $FrameworkDate · 5 platforms             │" -ForegroundColor Cyan
-Write-Host "  └─────────────────────────────────────────────────────┘" -ForegroundColor Cyan
+Write-Host "  +-----------------------------------------------------+" -ForegroundColor Cyan
+Write-Host "  |  SkillFoundry Framework -- Installer                    |" -ForegroundColor Cyan
+Write-Host "  |  v$FrameworkVersion * $FrameworkDate * 5 platforms             |" -ForegroundColor Cyan
+Write-Host "  +-----------------------------------------------------+" -ForegroundColor Cyan
 Write-Host ""
 
 # Platform selection if not specified
@@ -329,9 +329,9 @@ Write-Host ""
 
 # Check if user accidentally copied skillfoundry into their project
 if (Test-Path (Join-Path $TargetDir "skillfoundry")) {
-    Write-ColorOutput "╔═══════════════════════════════════════════════════════════╗" "Red"
-    Write-ColorOutput "║  ERROR: Found 'skillfoundry' folder in target directory!     ║" "Red"
-    Write-ColorOutput "╚═══════════════════════════════════════════════════════════╝" "Red"
+    Write-ColorOutput "+===========================================================+" "Red"
+    Write-ColorOutput "|  ERROR: Found 'skillfoundry' folder in target directory!     |" "Red"
+    Write-ColorOutput "+===========================================================+" "Red"
     Write-Host ""
     Write-ColorOutput "You should NOT copy the skillfoundry folder into your project." "Yellow"
     Write-Host ""
@@ -362,9 +362,9 @@ if (Test-Path (Join-Path $TargetDir "skillfoundry")) {
 
 # Check if installing into the skillfoundry source folder itself
 if ($TargetDir -eq $ScriptDir) {
-    Write-ColorOutput "╔═══════════════════════════════════════════════════════════╗" "Red"
-    Write-ColorOutput "║  ERROR: Cannot install into the source folder itself!     ║" "Red"
-    Write-ColorOutput "╚═══════════════════════════════════════════════════════════╝" "Red"
+    Write-ColorOutput "+===========================================================+" "Red"
+    Write-ColorOutput "|  ERROR: Cannot install into the source folder itself!     |" "Red"
+    Write-ColorOutput "+===========================================================+" "Red"
     Write-Host ""
     Write-Host "You're trying to install into the skillfoundry template folder."
     Write-Host ""
@@ -414,14 +414,14 @@ foreach ($plat in $Platforms) {
     }
 }
 
-# ═══════════════════════════════════════════════════════════════
+# ===============================================================
 # DRY-RUN: Preview what would be installed, then exit
-# ═══════════════════════════════════════════════════════════════
+# ===============================================================
 if ($DryRun) {
     Write-Host ""
-    Write-Host "  ┌─────────────────────────────────────────────────────┐" -ForegroundColor Cyan
-    Write-Host "  │  Dry Run — No files will be modified               │" -ForegroundColor Cyan
-    Write-Host "  └─────────────────────────────────────────────────────┘" -ForegroundColor Cyan
+    Write-Host "  +-----------------------------------------------------+" -ForegroundColor Cyan
+    Write-Host "  |  Dry Run -- No files will be modified               |" -ForegroundColor Cyan
+    Write-Host "  +-----------------------------------------------------+" -ForegroundColor Cyan
     Write-Host ""
     Write-Host "  Target:     $TargetDir"
     Write-Host "  Platforms:  $PlatformDisplay"
@@ -463,12 +463,12 @@ if ($DryRun) {
     exit 0
 }
 
-# ═══════════════════════════════════════════════════════════════
+# ===============================================================
 # Initialize progress counter
-# ═══════════════════════════════════════════════════════════════
+# ===============================================================
 Initialize-Steps (3 + $Platforms.Count + 3)
 
-# Create directory structure — shared directories (once)
+# Create directory structure -- shared directories (once)
 Write-Step "Creating shared directory structure..."
 New-Item -ItemType Directory -Force -Path (Join-Path $TargetDir "agents") | Out-Null
 New-Item -ItemType Directory -Force -Path (Join-Path $TargetDir "genesis") | Out-Null
@@ -500,7 +500,7 @@ foreach ($plat in $Platforms) {
         Copy-Item -Path "$ScriptDir\.claude\commands\*" -Destination "$TargetDir\.claude\commands\" -Recurse -Force
         $count = (Get-ChildItem -Path "$TargetDir\.claude\commands\*.md" -ErrorAction SilentlyContinue).Count
         $PlatformCounts["claude"] = $count
-        Write-ColorOutput "  ✓ Claude skills installed ($count skills)" "Green"
+        Write-ColorOutput "  [OK] Claude skills installed ($count skills)" "Green"
     } elseif ($plat -eq "copilot") {
         Copy-Item -Path "$ScriptDir\.copilot\custom-agents\*" -Destination "$TargetDir\.copilot\custom-agents\" -Recurse -Force
         if (Test-Path "$ScriptDir\.copilot\helper.sh") {
@@ -511,32 +511,32 @@ foreach ($plat in $Platforms) {
         }
         $count = (Get-ChildItem -Path "$TargetDir\.copilot\custom-agents\*.md" -ErrorAction SilentlyContinue).Count
         $PlatformCounts["copilot"] = $count
-        Write-ColorOutput "  ✓ Copilot custom agents installed ($count agents)" "Green"
-        Write-ColorOutput "  ✓ Copilot helper and workflow guide installed" "Green"
+        Write-ColorOutput "  [OK] Copilot custom agents installed ($count agents)" "Green"
+        Write-ColorOutput "  [OK] Copilot helper and workflow guide installed" "Green"
     } elseif ($plat -eq "codex") {
         Copy-Item -Path "$ScriptDir\.agents\skills\*" -Destination "$TargetDir\.agents\skills\" -Recurse -Force
         Copy-Item -Path "$ScriptDir\AGENTS.md" -Destination "$TargetDir\AGENTS.md" -Force
         $count = (Get-ChildItem -Path "$TargetDir\.agents\skills\*\SKILL.md" -ErrorAction SilentlyContinue).Count
         $PlatformCounts["codex"] = $count
-        Write-ColorOutput "  ✓ Codex skills installed ($count skills)" "Green"
-        Write-ColorOutput "  ✓ AGENTS.md installed" "Green"
+        Write-ColorOutput "  [OK] Codex skills installed ($count skills)" "Green"
+        Write-ColorOutput "  [OK] AGENTS.md installed" "Green"
     } elseif ($plat -eq "gemini") {
         Copy-Item -Path "$ScriptDir\.gemini\skills\*" -Destination "$TargetDir\.gemini\skills\" -Recurse -Force
         $count = (Get-ChildItem -Path "$TargetDir\.gemini\skills\*.md" -ErrorAction SilentlyContinue).Count
         $PlatformCounts["gemini"] = $count
-        Write-ColorOutput "  ✓ Gemini skills installed ($count skills)" "Green"
+        Write-ColorOutput "  [OK] Gemini skills installed ($count skills)" "Green"
     } elseif ($plat -eq "cursor") {
         Copy-Item -Path "$ScriptDir\.cursor\rules\*" -Destination "$TargetDir\.cursor\rules\" -Recurse -Force
         $count = (Get-ChildItem -Path "$TargetDir\.cursor\rules\*.md" -ErrorAction SilentlyContinue).Count
         $PlatformCounts["cursor"] = $count
-        Write-ColorOutput "  ✓ Cursor rules installed ($count rules)" "Green"
+        Write-ColorOutput "  [OK] Cursor rules installed ($count rules)" "Green"
     }
 }
 
 Write-Step "Installing shared agent modules..."
 Copy-Item -Path "$ScriptDir\agents\*" -Destination "$TargetDir\agents\" -Recurse -Force
 $SharedCount = (Get-ChildItem -Path "$TargetDir\agents\*.md" -ErrorAction SilentlyContinue).Count
-Write-ColorOutput "  ✓ Shared agent modules installed ($SharedCount modules)" "Green"
+Write-ColorOutput "  [OK] Shared agent modules installed ($SharedCount modules)" "Green"
 
 Write-Step "Installing templates and documentation..."
 
@@ -545,41 +545,41 @@ if (Test-Path (Join-Path $TargetDir "CLAUDE.md")) {
     Write-ColorOutput "  CLAUDE.md already exists." "Yellow"
     if ($Yes) {
         Copy-Item -Path "$ScriptDir\CLAUDE.md" -Destination "$TargetDir\CLAUDE.md" -Force
-        Write-ColorOutput "  ✓ CLAUDE.md updated (-Yes)" "Green"
+        Write-ColorOutput "  [OK] CLAUDE.md updated (-Yes)" "Green"
     } else {
         $response = Read-Host "  Overwrite? (y/N)"
         if ($response -match "^[Yy]$") {
             Copy-Item -Path "$ScriptDir\CLAUDE.md" -Destination "$TargetDir\CLAUDE.md" -Force
-            Write-ColorOutput "  ✓ CLAUDE.md updated" "Green"
+            Write-ColorOutput "  [OK] CLAUDE.md updated" "Green"
         } else {
-            Write-ColorOutput "  → Keeping existing CLAUDE.md" "Yellow"
+            Write-ColorOutput "  -> Keeping existing CLAUDE.md" "Yellow"
         }
     }
 } else {
     Copy-Item -Path "$ScriptDir\CLAUDE.md" -Destination "$TargetDir\CLAUDE.md" -Force
-    Write-ColorOutput "  ✓ CLAUDE.md installed" "Green"
+    Write-ColorOutput "  [OK] CLAUDE.md installed" "Green"
 }
 
 # Copy PRD template
 Copy-Item -Path "$ScriptDir\genesis\TEMPLATE.md" -Destination "$TargetDir\genesis\" -Force
-Write-ColorOutput "  ✓ PRD template installed to genesis/" "Green"
+Write-ColorOutput "  [OK] PRD template installed to genesis/" "Green"
 
 # Copy security anti-pattern documents to docs/
 if (-not (Test-Path (Join-Path $TargetDir "docs\ANTI_PATTERNS_BREADTH.md"))) {
     Copy-Item -Path "$ScriptDir\docs\ANTI_PATTERNS_BREADTH.md" -Destination (Join-Path $TargetDir "docs\") -Force
-    Write-ColorOutput "  ✓ docs/ANTI_PATTERNS_BREADTH.md installed" "Green"
+    Write-ColorOutput "  [OK] docs/ANTI_PATTERNS_BREADTH.md installed" "Green"
 }
 
 if (-not (Test-Path (Join-Path $TargetDir "docs\ANTI_PATTERNS_DEPTH.md"))) {
     Copy-Item -Path "$ScriptDir\docs\ANTI_PATTERNS_DEPTH.md" -Destination (Join-Path $TargetDir "docs\") -Force
-    Write-ColorOutput "  ✓ docs/ANTI_PATTERNS_DEPTH.md installed" "Green"
+    Write-ColorOutput "  [OK] docs/ANTI_PATTERNS_DEPTH.md installed" "Green"
 }
 
 # Copy knowledge bootstrap for memory/harvest system
 $BootstrapTarget = Join-Path $TargetDir "memory_bank\knowledge\bootstrap.jsonl"
 if (-not (Test-Path $BootstrapTarget)) {
     Copy-Item -Path "$ScriptDir\memory_bank\knowledge\bootstrap.jsonl" -Destination $BootstrapTarget -Force
-    Write-ColorOutput "  ✓ memory_bank/knowledge/ initialized with bootstrap" "Green"
+    Write-ColorOutput "  [OK] memory_bank/knowledge/ initialized with bootstrap" "Green"
 }
 
 # Set framework version markers
@@ -597,7 +597,7 @@ foreach ($plat in $Platforms) {
     $FrameworkDate | Out-File -FilePath (Join-Path $TargetDir "$platDir\.framework-updated") -Encoding utf8 -NoNewline
     $plat | Out-File -FilePath (Join-Path $TargetDir "$platDir\.framework-platform") -Encoding utf8 -NoNewline
 }
-Write-ColorOutput "  ✓ Framework version: v$FrameworkVersion (Platform(s): $PlatformDisplay)" "Green"
+Write-ColorOutput "  [OK] Framework version: v$FrameworkVersion (Platform(s): $PlatformDisplay)" "Green"
 
 $RegistryFile = Join-Path $ScriptDir ".project-registry"
 $RegistryContent = @()
@@ -607,11 +607,11 @@ if (Test-Path $RegistryFile) {
 if ($RegistryContent -notcontains $TargetDir) {
     Add-Content -Path $RegistryFile -Value $TargetDir
 }
-Write-ColorOutput "  ✓ Registered for framework updates" "Green"
+Write-ColorOutput "  [OK] Registered for framework updates" "Green"
 
-# ═══════════════════════════════════════════════════════════════
+# ===============================================================
 # PHASE 3: Build and deploy SkillFoundry CLI (sf command)
-# ═══════════════════════════════════════════════════════════════
+# ===============================================================
 Write-Step "Building SkillFoundry CLI..."
 $SF_CLI_INSTALLED = $false
 
@@ -677,7 +677,7 @@ if ($nodeCmd) {
                     "set SF_FRAMEWORK_ROOT=$ScriptDir`r`n" +
                     "node `"%SF_FRAMEWORK_ROOT%\sf_cli\bin\sf.js`" %*`r`n"
                 $cmdContent | Out-File -FilePath $SF_WRAPPER_CMD -Encoding ascii -NoNewline
-                Write-ColorOutput "  ✓ CLI wrapper installed: $SF_WRAPPER_CMD" "Green"
+                Write-ColorOutput "  [OK] CLI wrapper installed: $SF_WRAPPER_CMD" "Green"
 
                 # Create .ps1 wrapper (for PowerShell direct invocation)
                 $SF_WRAPPER_PS1 = Join-Path $SF_WRAPPER_DIR "sf.ps1"
@@ -689,17 +689,17 @@ if ($nodeCmd) {
                     "`$env:SF_FRAMEWORK_ROOT = `"$ScriptDir`"`r`n" +
                     "& node `"`$env:SF_FRAMEWORK_ROOT\sf_cli\bin\sf.js`" @args`r`n"
                 $ps1Content | Out-File -FilePath $SF_WRAPPER_PS1 -Encoding utf8
-                Write-ColorOutput "  ✓ PowerShell wrapper installed: $SF_WRAPPER_PS1" "Green"
+                Write-ColorOutput "  [OK] PowerShell wrapper installed: $SF_WRAPPER_PS1" "Green"
 
                 $SF_CLI_INSTALLED = $true
 
                 # Check if wrapper dir is on PATH
                 $userPath = [Environment]::GetEnvironmentVariable("Path", "User")
                 if ($userPath -split ';' | Where-Object { $_ -eq $SF_WRAPPER_DIR }) {
-                    Write-ColorOutput "  ✓ $SF_WRAPPER_DIR is on PATH" "Green"
+                    Write-ColorOutput "  [OK] $SF_WRAPPER_DIR is on PATH" "Green"
                 } else {
                     Write-Host ""
-                    Write-ColorOutput "  ⚠ $SF_WRAPPER_DIR is not on your PATH" "Yellow"
+                    Write-ColorOutput "  [!] $SF_WRAPPER_DIR is not on your PATH" "Yellow"
                     Write-Host ""
                     Write-Host "  To add it permanently, run (as your user):"
                     Write-Host ""
@@ -727,9 +727,9 @@ Write-Step "Done!"
 $Elapsed = Get-ElapsedSeconds
 
 Write-Host ""
-Write-Host "  ┌─────────────────────────────────────────────────────┐" -ForegroundColor Green
-Write-Host "  │  Installation Complete                              │" -ForegroundColor Green
-Write-Host "  └─────────────────────────────────────────────────────┘" -ForegroundColor Green
+Write-Host "  +-----------------------------------------------------+" -ForegroundColor Green
+Write-Host "  |  Installation Complete                              |" -ForegroundColor Green
+Write-Host "  +-----------------------------------------------------+" -ForegroundColor Green
 Write-Host ""
 Write-Host "  Project:    $TargetDir"
 Write-Host "  Version:    v$FrameworkVersion"
@@ -749,7 +749,7 @@ foreach ($plat in $Platforms) {
 Write-Host "    agents/                 $SharedCount shared modules"
 Write-Host "    genesis/                PRD template"
 if ($SF_CLI_INSTALLED) {
-    Write-Host "    sf CLI                  ✓ installed (sf.cmd + sf.ps1)"
+    Write-Host "    sf CLI                  [OK] installed (sf.cmd + sf.ps1)"
 } else {
     Write-Host "    sf CLI                  - skipped (Node.js 20+ required)"
 }
@@ -769,7 +769,7 @@ foreach ($plat in $Platforms) {
         }
         "cursor" {
             Write-Host "    Cursor:" -ForegroundColor Cyan
-            Write-Host "      Open project in Cursor — rules auto-load from .cursor/rules/"
+            Write-Host "      Open project in Cursor -- rules auto-load from .cursor/rules/"
             Write-Host "      Create PRDs in genesis/ using genesis/TEMPLATE.md"
             Write-Host ""
         }

--- a/scripts/install-unified.ps1
+++ b/scripts/install-unified.ps1
@@ -23,9 +23,9 @@ function Write-ColorOutput {
 
 # Banner
 Write-Host ""
-Write-Host "  ┌─────────────────────────────────────────────────────┐" -ForegroundColor Cyan
-Write-Host "  │  SkillFoundry Framework — One-Click Installer          │" -ForegroundColor Cyan
-Write-Host "  └─────────────────────────────────────────────────────┘" -ForegroundColor Cyan
+Write-Host "  +-----------------------------------------------------+" -ForegroundColor Cyan
+Write-Host "  |  SkillFoundry Framework -- One-Click Installer          |" -ForegroundColor Cyan
+Write-Host "  +-----------------------------------------------------+" -ForegroundColor Cyan
 Write-Host ""
 
 # Detect platforms (Claude Code, Copilot CLI, Cursor, Codex, Gemini)
@@ -35,14 +35,14 @@ function Detect-Platform {
     # Check for Claude Code
     if (Get-Command claude -ErrorAction SilentlyContinue) {
         $platforms += "claude"
-        Write-ColorOutput "✓ Detected: Claude Code" "Green"
+        Write-ColorOutput "[OK] Detected: Claude Code" "Green"
     }
 
     # Check for GitHub Copilot CLI
     if ((Get-Command github-copilot-cli -ErrorAction SilentlyContinue) -or
         (Get-Command copilot -ErrorAction SilentlyContinue)) {
         $platforms += "copilot"
-        Write-ColorOutput "✓ Detected: GitHub Copilot CLI" "Green"
+        Write-ColorOutput "[OK] Detected: GitHub Copilot CLI" "Green"
     }
 
     # Check for Cursor
@@ -62,18 +62,18 @@ function Detect-Platform {
 
     if ($cursorFound -or (Get-Command cursor -ErrorAction SilentlyContinue)) {
         $platforms += "cursor"
-        Write-ColorOutput "✓ Detected: Cursor" "Green"
+        Write-ColorOutput "[OK] Detected: Cursor" "Green"
     }
 
     # Check for OpenAI Codex CLI
     if (Get-Command codex -ErrorAction SilentlyContinue) {
         $platforms += "codex"
-        Write-ColorOutput "✓ Detected: OpenAI Codex" "Green"
+        Write-ColorOutput "[OK] Detected: OpenAI Codex" "Green"
     }
     # Check for Google Gemini CLI
     if (Get-Command gemini -ErrorAction SilentlyContinue) {
         $platforms += "gemini"
-        Write-ColorOutput "✓ Detected: Google Gemini" "Green"
+        Write-ColorOutput "[OK] Detected: Google Gemini" "Green"
     }
 
     return ,$platforms
@@ -125,10 +125,10 @@ function Get-TargetDirectory {
     }
     
     if ($isProject) {
-        Write-ColorOutput "✓ Detected project directory: $(Split-Path $target -Leaf)" "Green"
+        Write-ColorOutput "[OK] Detected project directory: $(Split-Path $target -Leaf)" "Green"
         return $target
     } else {
-        Write-ColorOutput "⚠ Not in a project directory. Install to current directory?" "Yellow"
+        Write-ColorOutput "[!] Not in a project directory. Install to current directory?" "Yellow"
         $response = Read-Host "Continue? (y/N)"
         if ($response -notmatch "^[Yy]$") {
             $target = Read-Host "Enter project directory path"
@@ -180,12 +180,12 @@ function Select-PlatformsFromMenu {
 # Main installation flow
 function Main {
     Write-ColorOutput "Step 1: Detecting environment..." "Blue"
-    Write-ColorOutput "✓ OS: Windows" "Green"
+    Write-ColorOutput "[OK] OS: Windows" "Green"
 
     $detected = Detect-Platform
 
     if ($detected.Count -eq 0) {
-        Write-ColorOutput "⚠ No AI platform detected automatically." "Yellow"
+        Write-ColorOutput "[!] No AI platform detected automatically." "Yellow"
         $platforms = Select-PlatformsFromMenu
     } else {
         $detectedList = $detected -join ", "
@@ -206,25 +206,25 @@ function Main {
     }
 
     $platformsList = $platforms -join ", "
-    Write-ColorOutput "✓ Platforms: $platformsList" "Green"
+    Write-ColorOutput "[OK] Platforms: $platformsList" "Green"
 
     Write-Host ""
     Write-ColorOutput "Step 2: Locating framework..." "Blue"
     $frameworkDir = Get-FrameworkLocation
-    Write-ColorOutput "✓ Framework: $frameworkDir" "Green"
+    Write-ColorOutput "[OK] Framework: $frameworkDir" "Green"
 
     Write-Host ""
     Write-ColorOutput "Step 3: Selecting target project..." "Blue"
     $targetDir = Get-TargetDirectory
-    Write-ColorOutput "✓ Target: $targetDir" "Green"
+    Write-ColorOutput "[OK] Target: $targetDir" "Green"
 
     Write-Host ""
     Write-ColorOutput "Installation Summary:" "Cyan"
-    Write-Host "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+    Write-Host "===================================================="
     Write-Host "  Platforms: $platformsList"
     Write-Host "  Framework: $frameworkDir"
     Write-Host "  Target: $targetDir"
-    Write-Host "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+    Write-Host "===================================================="
     Write-Host ""
 
     if (-not $Silent) {
@@ -243,7 +243,7 @@ function Main {
     & "$frameworkDir\install.ps1" -Platform $platformCsv -TargetDir $targetDir -Yes
 
     Write-Host ""
-    Write-ColorOutput "✓ Installation Complete!" "Green"
+    Write-ColorOutput "[OK] Installation Complete!" "Green"
     Write-Host ""
     Write-Host "Next steps:"
     foreach ($plat in $platforms) {

--- a/scripts/memory.ps1
+++ b/scripts/memory.ps1
@@ -138,7 +138,7 @@ function Remember-Knowledge {
     $entry | ConvertTo-Json -Compress | Add-Content -Path $file
     
     Write-Host "MEMORY STORED" -ForegroundColor Green
-    Write-Host "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+    Write-Host "===================================================="
     Write-Host "ID: $id"
     Write-Host "Type: $Type"
     Write-Host "Content: $($Content.Substring(0, [Math]::Min(100, $Content.Length)))..."
@@ -163,7 +163,7 @@ function Recall-Knowledge {
     Initialize-MemoryBank
     
     Write-Host "MEMORY SEARCH: `"$Query`"" -ForegroundColor Cyan
-    Write-Host "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+    Write-Host "===================================================="
     
     $files = @()
     if ([string]::IsNullOrWhiteSpace($Type)) {
@@ -317,9 +317,9 @@ function Correct-Knowledge {
     $newEntry | ConvertTo-Json -Compress | Add-Content -Path $oldFile
     
     Write-Host "KNOWLEDGE CORRECTED" -ForegroundColor Green
-    Write-Host "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+    Write-Host "===================================================="
     Write-Host "Old Entry: [ID: $OldId]"
-    Write-Host "  Weight: $oldWeight → $newWeight (reduced)"
+    Write-Host "  Weight: $oldWeight -> $newWeight (reduced)"
     Write-Host ""
     Write-Host "New Entry: [ID: $newId]"
     Write-Host "  Weight: 0.7 (initial)"
@@ -340,7 +340,7 @@ switch ($Command) {
     "status" {
         Initialize-MemoryBank
         Write-Host "MEMORY STATUS" -ForegroundColor Cyan
-        Write-Host "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+        Write-Host "===================================================="
         foreach ($file in (Get-ChildItem -Path $KnowledgeDir -Filter "*.jsonl")) {
             $count = (Get-Content $file.FullName | Where-Object { $_ -and $_.Trim() }).Count
             $name = $file.BaseName

--- a/scripts/wizard.ps1
+++ b/scripts/wizard.ps1
@@ -26,10 +26,10 @@ $ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
 $ScriptDir = Split-Path -Parent $ScriptDir
 
 # Banner
-Write-ColorOutput "╔═══════════════════════════════════════════════════════════╗" "Cyan"
-Write-ColorOutput "║        SkillFoundry Framework - Quick Start Wizard          ║" "Cyan"
-Write-ColorOutput "║        Get started in 5 minutes!                         ║" "Cyan"
-Write-ColorOutput "╚═══════════════════════════════════════════════════════════╝" "Cyan"
+Write-ColorOutput "+===========================================================+" "Cyan"
+Write-ColorOutput "|        SkillFoundry Framework - Quick Start Wizard          |" "Cyan"
+Write-ColorOutput "|        Get started in 5 minutes!                         |" "Cyan"
+Write-ColorOutput "+===========================================================+" "Cyan"
 Write-Host ""
 
 # Step 1: Platform Selection
@@ -261,7 +261,7 @@ Build a $ProjectType using $TechStack to solve the problem described above.
 "@
     
     $prdContent | Out-File -FilePath $prdFile -Encoding UTF8
-    Write-ColorOutput "✓ Created starter PRD: $prdFile" "Green"
+    Write-ColorOutput "[OK] Created starter PRD: $prdFile" "Green"
     return $prdFile
 }
 
@@ -273,11 +273,11 @@ function Main {
     
     Write-Host ""
     Write-ColorOutput "Summary:" "Cyan"
-    Write-Host "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+    Write-Host "===================================================="
     Write-Host "  Platform: $platform"
     Write-Host "  Project Type: $projectType"
     Write-Host "  Tech Stack: $techStack"
-    Write-Host "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+    Write-Host "===================================================="
     Write-Host ""
     
     if (-not $Silent) {
@@ -297,7 +297,7 @@ function Main {
     $prdFile = Generate-StarterPRD $projectType $techStack
     
     Write-Host ""
-    Write-ColorOutput "✓ Setup Complete!" "Green"
+    Write-ColorOutput "[OK] Setup Complete!" "Green"
     Write-Host ""
     Write-Host "Next steps:"
     Write-Host "  1. Review PRD: Get-Content $prdFile"

--- a/update.ps1
+++ b/update.ps1
@@ -30,9 +30,9 @@ trap {
     $exitCode = $_.Exception.HResult
     if ($exitCode -eq 0) { $exitCode = 1 }
     
-    Write-ColorOutput "`n╔═══════════════════════════════════════════════════════════╗" "Red"
-    Write-ColorOutput "║                    ERROR OCCURRED                          ║" "Red"
-    Write-ColorOutput "╚═══════════════════════════════════════════════════════════╝" "Red"
+    Write-ColorOutput "`n+===========================================================+" "Red"
+    Write-ColorOutput "|                    ERROR OCCURRED                          |" "Red"
+    Write-ColorOutput "+===========================================================+" "Red"
     Write-ColorOutput "Error: Update failed" "Red"
     Write-ColorOutput "  Reason: $($_.Exception.Message)" "Yellow"
     Write-ColorOutput "  Location: $($_.InvocationInfo.ScriptLineNumber)" "Yellow"
@@ -150,16 +150,16 @@ if (-not (Test-Path $VersionFile)) {
 $FrameworkVersion = (Get-Content $VersionFile -Raw).Trim()
 $FrameworkDate = (Get-Item -Force $VersionFile).LastWriteTime.ToString("yyyy-MM-dd")
 
-# ═══════════════════════════════════════════════════════════════
+# ===============================================================
 # HELPER FUNCTIONS
-# ═══════════════════════════════════════════════════════════════
+# ===============================================================
 
 function Print-Header {
     Write-Host ""
-    Write-Host "  ┌─────────────────────────────────────────────────────┐" -ForegroundColor Cyan
-    Write-Host "  │  SkillFoundry Framework — Updater                     │" -ForegroundColor Cyan
-    Write-Host "  │  v$FrameworkVersion · $FrameworkDate · 5 platforms             │" -ForegroundColor Cyan
-    Write-Host "  └─────────────────────────────────────────────────────┘" -ForegroundColor Cyan
+    Write-Host "  +-----------------------------------------------------+" -ForegroundColor Cyan
+    Write-Host "  |  SkillFoundry Framework -- Updater                     |" -ForegroundColor Cyan
+    Write-Host "  |  v$FrameworkVersion * $FrameworkDate * 5 platforms             |" -ForegroundColor Cyan
+    Write-Host "  +-----------------------------------------------------+" -ForegroundColor Cyan
     Write-Host ""
 }
 
@@ -184,7 +184,7 @@ function Show-WhatsNew {
 
     Write-Host ""
     Write-Host "  What's New in v$Ver" -ForegroundColor Cyan
-    Write-Host "  $(('─' * 40))" -ForegroundColor Cyan
+    Write-Host "  $(('-' * 40))" -ForegroundColor Cyan
 
     $inBlock = $false
     $lineCount = 0
@@ -196,7 +196,7 @@ function Show-WhatsNew {
         if ($inBlock) {
             if ($line -match '^## \[' -or $line -match '^---$') { break }
             if ($line -match '^### (.+)') {
-                $heading = $Matches[1] -replace ' —.*', ''
+                $heading = $Matches[1] -replace ' --.*', ''
                 Write-Host "    $heading" -ForegroundColor Yellow
             } elseif ($line -match '^- (.+)' -and $lineCount -lt 10) {
                 $bullet = $Matches[1]
@@ -316,9 +316,9 @@ function Backup-File {
     return $null
 }
 
-# ═══════════════════════════════════════════════════════════════
+# ===============================================================
 # REGISTRY FUNCTIONS
-# ═══════════════════════════════════════════════════════════════
+# ===============================================================
 
 function Register-Project {
     param([string]$ProjectDir)
@@ -401,9 +401,9 @@ function Show-ProjectList {
     Write-ColorOutput "Framework version: $FrameworkVersion" "Cyan"
 }
 
-# ═══════════════════════════════════════════════════════════════
+# ===============================================================
 # UPDATE FUNCTION
-# ═══════════════════════════════════════════════════════════════
+# ===============================================================
 
 function Update-Project {
     param(
@@ -435,7 +435,7 @@ function Update-Project {
     Start-Timer
 
     Write-ColorOutput "Updating: $ProjectDir" "Blue"
-    Write-ColorOutput "  Current: v$currentVersion → Target: v$FrameworkVersion" "Blue"
+    Write-ColorOutput "  Current: v$currentVersion -> Target: v$FrameworkVersion" "Blue"
     Write-Host ""
     
     # Create backup directory
@@ -454,7 +454,7 @@ function Update-Project {
     Write-ColorOutput "Detected platforms: $($platforms -join ', ')" "Cyan"
     Write-Host ""
 
-    # ── Per-platform updates (loop) ──────────────────────────────
+    # -- Per-platform updates (loop) ------------------------------
     foreach ($plat in $platforms) {
         Write-ColorOutput "Updating platform: $plat" "Blue"
 
@@ -650,7 +650,7 @@ function Update-Project {
         Write-Host ""
     }
 
-    # ── Shared updates (once) ────────────────────────────────────
+    # -- Shared updates (once) ------------------------------------
 
     # Update shared agents
     Write-Host ""
@@ -674,7 +674,7 @@ function Update-Project {
             if ($sourceContent.Hash -ne $targetContent.Hash) {
                 Backup-File $target | Out-Null
                 Copy-Item -Path $agent.FullName -Destination $target -Force
-                Write-ColorOutput "  ↑ Updated: $agentName" "Cyan"
+                Write-ColorOutput "  ^ Updated: $agentName" "Cyan"
                 $agentsUpdated++
             }
         }
@@ -714,17 +714,17 @@ function Update-Project {
             switch ($choice) {
                 "1" {
                     Copy-Item -Path "$ScriptDir\CLAUDE.md" -Destination (Join-Path $ProjectDir "CLAUDE.md") -Force
-                    Write-ColorOutput "  ✓ CLAUDE.md overwritten (backup saved)" "Green"
+                    Write-ColorOutput "  [OK] CLAUDE.md overwritten (backup saved)" "Green"
                 }
                 "2" {
-                    Write-ColorOutput "  → Keeping current CLAUDE.md" "Yellow"
+                    Write-ColorOutput "  -> Keeping current CLAUDE.md" "Yellow"
                 }
                 "3" {
                     Copy-Item -Path "$ScriptDir\CLAUDE.md" -Destination (Join-Path $ProjectDir "CLAUDE.md.new") -Force
-                    Write-ColorOutput "  → Saved as CLAUDE.md.new - merge manually" "Cyan"
+                    Write-ColorOutput "  -> Saved as CLAUDE.md.new - merge manually" "Cyan"
                 }
                 default {
-                    Write-ColorOutput "  → Keeping current CLAUDE.md" "Yellow"
+                    Write-ColorOutput "  -> Keeping current CLAUDE.md" "Yellow"
                 }
             }
         } else {
@@ -732,7 +732,7 @@ function Update-Project {
         }
     } else {
         Copy-Item -Path "$ScriptDir\CLAUDE.md" -Destination (Join-Path $ProjectDir "CLAUDE.md") -Force
-        Write-ColorOutput "  ✓ CLAUDE.md installed" "Green"
+        Write-ColorOutput "  [OK] CLAUDE.md installed" "Green"
     }
     
     # Update templates and security documents
@@ -752,7 +752,7 @@ function Update-Project {
             if ($sourceHash -ne $targetHash) {
                 Backup-File $templateTarget | Out-Null
                 Copy-Item -Path "$ScriptDir\genesis\TEMPLATE.md" -Destination $templateTarget -Force
-                Write-ColorOutput "  ↑ Updated: genesis/TEMPLATE.md" "Cyan"
+                Write-ColorOutput "  ^ Updated: genesis/TEMPLATE.md" "Cyan"
             }
         }
     }
@@ -775,7 +775,7 @@ function Update-Project {
                 if ($sourceHash -ne $targetHash) {
                     Backup-File $docTarget | Out-Null
                     Copy-Item -Path $sourcePath -Destination $docTarget -Force
-                    Write-ColorOutput "  ↑ Updated: $doc" "Cyan"
+                    Write-ColorOutput "  ^ Updated: $doc" "Cyan"
                 }
             }
         }
@@ -796,7 +796,7 @@ function Update-Project {
                     & npm install --production=false --silent 2>&1 | Out-Null
                     & npm run build 2>&1 | Out-Null
                     if ($LASTEXITCODE -eq 0) {
-                        Write-ColorOutput "  ✓ CLI rebuilt successfully" "Green"
+                        Write-ColorOutput "  [OK] CLI rebuilt successfully" "Green"
 
                         # Regenerate wrappers if they exist (framework root may have moved)
                         $SF_WRAPPER_DIR = Join-Path $env:USERPROFILE ".local\bin"
@@ -811,7 +811,7 @@ function Update-Project {
                                 "set SF_FRAMEWORK_ROOT=$ScriptDir`r`n" +
                                 "node `"%SF_FRAMEWORK_ROOT%\sf_cli\bin\sf.js`" %*`r`n"
                             $cmdContent | Out-File -FilePath $SF_WRAPPER_CMD -Encoding ascii -NoNewline
-                            Write-ColorOutput "  ✓ CLI wrapper updated: $SF_WRAPPER_CMD" "Green"
+                            Write-ColorOutput "  [OK] CLI wrapper updated: $SF_WRAPPER_CMD" "Green"
                         }
                         $SF_WRAPPER_PS1 = Join-Path $SF_WRAPPER_DIR "sf.ps1"
                         if (Test-Path $SF_WRAPPER_PS1) {
@@ -823,13 +823,13 @@ function Update-Project {
                                 "`$env:SF_FRAMEWORK_ROOT = `"$ScriptDir`"`r`n" +
                                 "& node `"`$env:SF_FRAMEWORK_ROOT\sf_cli\bin\sf.js`" @args`r`n"
                             $ps1Content | Out-File -FilePath $SF_WRAPPER_PS1 -Encoding utf8
-                            Write-ColorOutput "  ✓ PowerShell wrapper updated: $SF_WRAPPER_PS1" "Green"
+                            Write-ColorOutput "  [OK] PowerShell wrapper updated: $SF_WRAPPER_PS1" "Green"
                         }
                     } else {
-                        Write-ColorOutput "  ⚠ CLI build failed (non-critical)" "Yellow"
+                        Write-ColorOutput "  [!] CLI build failed (non-critical)" "Yellow"
                     }
                 } catch {
-                    Write-ColorOutput "  ⚠ CLI rebuild skipped: $($_.Exception.Message)" "Yellow"
+                    Write-ColorOutput "  [!] CLI rebuild skipped: $($_.Exception.Message)" "Yellow"
                 } finally {
                     Pop-Location
                 }
@@ -853,13 +853,13 @@ function Update-Project {
     $elapsed = Get-ElapsedSeconds
 
     Write-Host ""
-    Write-Host "  ┌─────────────────────────────────────────────────────┐" -ForegroundColor Green
-    Write-Host "  │  Update Complete                                    │" -ForegroundColor Green
-    Write-Host "  └─────────────────────────────────────────────────────┘" -ForegroundColor Green
+    Write-Host "  +-----------------------------------------------------+" -ForegroundColor Green
+    Write-Host "  |  Update Complete                                    |" -ForegroundColor Green
+    Write-Host "  +-----------------------------------------------------+" -ForegroundColor Green
     Write-Host ""
     Write-Host "  Project:    $ProjectDir"
     Write-Host "  Platforms:  $($platforms -join ', ')"
-    Write-Host "  Version:    v$currentVersion → v$FrameworkVersion"
+    Write-Host "  Version:    v$currentVersion -> v$FrameworkVersion"
     Write-Host "  Duration:   ${elapsed}s"
     Write-Host "  Backup:     $backupDir"
     Write-Host ""
@@ -907,14 +907,14 @@ function Update-AllProjects {
     }
     
     Write-Host ""
-    Write-ColorOutput "═══════════════════════════════════════════════════════════" "Cyan"
+    Write-ColorOutput "===========================================================" "Cyan"
     Write-ColorOutput "Summary: $total total, $updated updated, $failed failed" "Cyan"
-    Write-ColorOutput "═══════════════════════════════════════════════════════════" "Cyan"
+    Write-ColorOutput "===========================================================" "Cyan"
 }
 
-# ═══════════════════════════════════════════════════════════════
+# ===============================================================
 # MAIN
-# ═══════════════════════════════════════════════════════════════
+# ===============================================================
 
 Print-Header
 


### PR DESCRIPTION
…mpat

Windows PowerShell 5.1 reads .ps1 files without UTF-8 BOM as ANSI (Windows-1252). Multi-byte UTF-8 characters like checkmark (E2 9C 93) decode as smart-quote (0x93) which breaks the parser inside strings.

Replaced across all 6 .ps1 files:
- Box drawing (╔═╗║╚╝┌─┐│└┘━) -> ASCII (+=-|)
- Checkmark/warning/arrows (✓⚠→↑) -> [OK] [!] -> ^
- Em dash/middle dot (—·) -> -- *