### PR TITLE
refine: consolidation pass (§1.3 /forge note, §1.5 /auto→/forge)

### DIFF
--- a/.agents/skills/auto/SKILL.md
+++ b/.agents/skills/auto/SKILL.md
@@ -52,194 +52,20 @@ IF input is NEW_FEATURE and no PRD exists:
 
 ---
 
-## FULL PIPELINE (NEW_FEATURE / PRD_FEATURE)
+## FULL PIPELINE (NEW_FEATURE / PRD_FEATURE) — dispatches to /forge
 
-Execute these phases sequentially. Do not proceed if a phase fails.
+`/auto` does not run its own feature pipeline. For NEW_FEATURE and PRD_FEATURE it ensures a PRD exists, then **dispatches to `/forge`**, which owns the canonical pipeline: PRD validation → story generation → per-story implementation → Anvil (A0–A6) gates at every handoff → delivery audit → security audit → knowledge harvest → debrief. `/auto` feature runs therefore get the same gates and delivery audit as a direct `/forge` run — not a separate, drifting copy of the pipeline.
 
-### PHASE 0: PRD CREATION (if needed)
 ```
-[PRD MODE]
+PRD_FEATURE  (a PRD path is given, or a PRD already exists in genesis/):
+    → /forge [prd-file]
 
-Check: Does a PRD exist for this feature?
-
-IF NO PRD EXISTS:
-    1. Run PRD Architect interrogation
-    2. Extract requirements from user
-    3. Generate full PRD document
-    4. Save to: genesis/[YYYY-MM-DD]-[feature-slug].md
-    5. Present PRD for user approval
-
-IF PRD EXISTS:
-    → Load PRD
-    → Verify status is APPROVED or IMPLEMENTING
-    → Proceed to Phase 0.5
-
-OUTPUT: Approved PRD document
-GATE: PRD must be complete and approved before proceeding
+NEW_FEATURE  (no PRD yet):
+    → /prd "description"        # create the PRD in genesis/ (per PRD Detection Logic above)
+    → /forge                    # then run the full pipeline
 ```
 
-### PHASE 0.5: STORY GENERATION (if needed)
-```
-[STORY MODE]
-
-Check: Do implementation stories exist for this PRD?
-
-IF NO STORIES EXIST:
-    1. Parse PRD for user stories and functional requirements
-    2. Group into implementation stories
-    3. Generate hyper-detailed story files
-    4. Create dependency graph
-    5. Save to: docs/stories/[prd-slug]/
-
-IF STORIES EXIST:
-    → Load story index
-    → Identify next TODO story
-    → Check dependencies are satisfied
-
-OUTPUT: Story set with INDEX.md
-GATE: At least one story must be ready for implementation
-```
-
-### PHASE 1: REQUIREMENTS & ARCHITECTURE
-```
-[ARCHITECT MODE]
-
-Using PRD and current story as context:
-
-1. Validate story completeness
-   - Clear inputs and outputs
-   - Data models required
-   - User roles and permissions
-   - Error cases to handle
-
-2. Security review
-   - Authentication requirements
-   - Input validation needs
-   - Data exposure risks
-
-3. Architecture decision
-   - Components to create/modify
-   - Dependencies needed
-   - Integration points
-
-OUTPUT: Approved architecture for current story
-GATE: Architecture must align with PRD and story requirements
-```
-
-### PHASE 2: IMPLEMENTATION
-```
-[CODER MODE]
-
-Using the approved specification:
-1. Implement the feature
-   - Follow existing patterns in codebase
-   - Add comprehensive comments
-   - Include logging for all error paths
-   - No magic strings or hardcoded values
-
-2. Create test scaffolds
-   - Unit test file with structure
-   - Key test cases identified
-
-OUTPUT: Implementation code + test scaffolds
-GATE: Code must compile/parse without errors
-```
-
-### PHASE 3: TESTING
-```
-[TESTER MODE]
-
-Create and conceptualize tests:
-1. Positive test cases (happy path)
-2. Negative test cases (invalid inputs)
-3. Edge cases (boundaries, null, empty)
-4. Security probes (injection, XSS, auth bypass)
-
-OUTPUT: Test file with all cases
-GATE: All critical paths must have test coverage
-```
-
-### PHASE 4: VALIDATION
-```
-[GATE-KEEPER MODE] + [LAYER-CHECK MODE]
-
-STEP 1: BANNED PATTERN SCAN (BLOCKING)
-Run scan for: TODO, FIXME, PLACEHOLDER, STUB, MOCK, COMING SOON, NOT IMPLEMENTED
-ANY MATCH IN PRODUCTION CODE = IMMEDIATE REJECTION
-
-STEP 2: THREE-LAYER VALIDATION
-For each affected layer:
-
-DATABASE (if affected):
-□ Migration runs successfully
-□ Schema matches PRD data model
-□ Rollback tested
-□ Constraints and indexes in place
-
-BACKEND (if affected):
-□ All endpoints respond correctly
-□ Unit tests pass
-□ Integration tests pass
-□ Auth/authz enforced
-□ Input validation complete
-
-FRONTEND (if affected):
-□ Connected to REAL API (no mocks)
-□ All UI states implemented
-□ No placeholder text
-□ Accessibility verified
-
-STEP 3: ITERATION GATES
-□ Documentation complete
-□ Security scan clean
-□ Audit log entry created
-
-OUTPUT: Layer validation matrix + Gate status
-GATE: ALL affected layers must PASS, ALL iteration gates must PASS
-```
-
-### PHASE 4.5: SECURITY AUDIT
-```
-[SECURITY MODE]
-
-Mandatory security checks:
-1. No secrets in code (grep for passwords, api_key, secret)
-2. Input validation on all user inputs
-3. SQL injection prevention verified
-4. XSS prevention verified
-5. Auth tokens handled securely
-6. No sensitive data in logs
-7. CSRF protection in place
-
-OUTPUT: Security audit report
-GATE: Zero security violations allowed
-```
-
-### PHASE 5: DOCUMENTATION
-```
-[DOCS MODE]
-
-Create documentation:
-1. Feature purpose and usage
-2. API reference (if applicable)
-3. Code examples
-4. Known limitations
-
-OUTPUT: Documentation file
-```
-
-### PHASE 6: FINAL EVALUATION
-```
-[EVALUATOR MODE]
-
-Final review against BPSBS:
-1. Security compliance
-2. Code quality standards
-3. Test coverage
-4. Documentation completeness
-
-OUTPUT: Final verdict and any recommendations
-```
+The phases, gates, and delivery audit are `/forge`'s — see `/forge`. `/auto`'s role here is classification and dispatch, not re-implementing the pipeline.
 
 ---
 
@@ -421,25 +247,7 @@ Waiting for response...
 
 ## STORY LOOP
 
-When multiple stories exist, Auto Pilot loops through them:
-
-```
-FOR EACH story in dependency order:
-    IF story.status == TODO:
-        story.status = IN_PROGRESS
-        Execute PHASE 1-6 for this story
-        IF all phases pass:
-            story.status = DONE
-            Update INDEX.md
-        ELSE:
-            story.status = BLOCKED
-            Report blocker
-            Ask: Continue to next story or stop?
-
-    IF all stories DONE:
-        Run FINAL EVALUATION on complete feature
-        Generate feature completion report
-```
+Multi-story iteration for feature work is `/forge`'s responsibility, not `/auto`'s. When `/auto` dispatches a NEW_FEATURE / PRD_FEATURE to `/forge`, `/forge` loops through the generated stories in dependency order, gates each at every Anvil handoff, and produces the delivery audit and completion report. `/auto` does not run its own per-story phase loop.
 
 ---
 
@@ -452,18 +260,10 @@ User says:
 
 Auto Pilot executes:
 1. ✓ Classify: NEW_FEATURE (complex)
-2. ✓ PRD: Interrogate user, generate full PRD
-3. ✓ USER APPROVAL: Present PRD for sign-off
-4. ✓ STORIES: Generate 5 implementation stories
-5. ✓ STORY-001: Auth models → Architect → Code → Test → Gate → Docs
-6. ✓ STORY-002: Login API → Architect → Code → Test → Gate → Docs
-7. ✓ STORY-003: Logout → Architect → Code → Test → Gate → Docs
-8. ✓ STORY-004: Auth middleware → Architect → Code → Test → Gate → Docs
-9. ✓ STORY-005: Login UI → Architect → Code → Test → Gate → Docs
-10. ✓ EVALUATOR: Final BPSBS compliance check
-11. ✓ REPORT: Summary of all deliverables
+2. ✓ PRD: no PRD exists → run `/prd` to interrogate and generate it in genesis/ (user sign-off)
+3. ✓ Dispatch `/forge` — validates the PRD, generates stories, and runs the full gated pipeline (implement → Anvil gates → delivery audit → security → docs → harvest → debrief) for every story
 
-User receives: Complete, tested, documented authentication system with full PRD and story trail.
+User receives: Complete, tested, documented authentication system — with the same gates and delivery audit as a direct `/forge` run.
 
 ### Example 2: From Existing PRD
 
@@ -472,10 +272,7 @@ User says:
 
 Auto Pilot executes:
 1. ✓ Classify: PRD_FEATURE
-2. ✓ Load PRD (skip creation)
-3. ✓ STORIES: Generate or load existing stories
-4. ✓ Execute story loop
-5. ✓ REPORT
+2. ✓ Dispatch `/forge genesis/2026-01-16-user-auth.md` — PRD validation → stories → full gated pipeline → report
 
 ### Example 3: Simple Feature (Skip PRD)
 

--- a/.agents/skills/forge/SKILL.md
+++ b/.agents/skills/forge/SKILL.md
@@ -11,6 +11,8 @@ min_model: opus
 
 > The full pipeline: validate, implement, test, audit, and harvest — all in one command.
 
+> **Runtime note — two forges, one metaphor.** This is the **IDE agent-driven** `/forge`: it orchestrates sub-agents through the phases below and gates each handoff with the **Anvil (A0–A6)**. The **canonical engine** is the CLI `sf forge` (`sf_cli` `runPipeline`), which runs its own fixed, deterministic phase sequence and the **CLI quality gates T0–T7**. Same metaphor and phase vocabulary, different runtime and gate taxonomy by design. Use this skill inside an AI IDE; use `sf forge` for a self-contained CLI run.
+
 ---
 
 ## Usage

--- a/.claude/commands/auto.md
+++ b/.claude/commands/auto.md
@@ -46,194 +46,20 @@ IF input is NEW_FEATURE and no PRD exists:
 
 ---
 
-## FULL PIPELINE (NEW_FEATURE / PRD_FEATURE)
+## FULL PIPELINE (NEW_FEATURE / PRD_FEATURE) — dispatches to /forge
 
-Execute these phases sequentially. Do not proceed if a phase fails.
+`/auto` does not run its own feature pipeline. For NEW_FEATURE and PRD_FEATURE it ensures a PRD exists, then **dispatches to `/forge`**, which owns the canonical pipeline: PRD validation → story generation → per-story implementation → Anvil (A0–A6) gates at every handoff → delivery audit → security audit → knowledge harvest → debrief. `/auto` feature runs therefore get the same gates and delivery audit as a direct `/forge` run — not a separate, drifting copy of the pipeline.
 
-### PHASE 0: PRD CREATION (if needed)
 ```
-[PRD MODE]
+PRD_FEATURE  (a PRD path is given, or a PRD already exists in genesis/):
+    → /forge [prd-file]
 
-Check: Does a PRD exist for this feature?
-
-IF NO PRD EXISTS:
-    1. Run PRD Architect interrogation
-    2. Extract requirements from user
-    3. Generate full PRD document
-    4. Save to: genesis/[YYYY-MM-DD]-[feature-slug].md
-    5. Present PRD for user approval
-
-IF PRD EXISTS:
-    → Load PRD
-    → Verify status is APPROVED or IMPLEMENTING
-    → Proceed to Phase 0.5
-
-OUTPUT: Approved PRD document
-GATE: PRD must be complete and approved before proceeding
+NEW_FEATURE  (no PRD yet):
+    → /prd "description"        # create the PRD in genesis/ (per PRD Detection Logic above)
+    → /forge                    # then run the full pipeline
 ```
 
-### PHASE 0.5: STORY GENERATION (if needed)
-```
-[STORY MODE]
-
-Check: Do implementation stories exist for this PRD?
-
-IF NO STORIES EXIST:
-    1. Parse PRD for user stories and functional requirements
-    2. Group into implementation stories
-    3. Generate hyper-detailed story files
-    4. Create dependency graph
-    5. Save to: docs/stories/[prd-slug]/
-
-IF STORIES EXIST:
-    → Load story index
-    → Identify next TODO story
-    → Check dependencies are satisfied
-
-OUTPUT: Story set with INDEX.md
-GATE: At least one story must be ready for implementation
-```
-
-### PHASE 1: REQUIREMENTS & ARCHITECTURE
-```
-[ARCHITECT MODE]
-
-Using PRD and current story as context:
-
-1. Validate story completeness
-   - Clear inputs and outputs
-   - Data models required
-   - User roles and permissions
-   - Error cases to handle
-
-2. Security review
-   - Authentication requirements
-   - Input validation needs
-   - Data exposure risks
-
-3. Architecture decision
-   - Components to create/modify
-   - Dependencies needed
-   - Integration points
-
-OUTPUT: Approved architecture for current story
-GATE: Architecture must align with PRD and story requirements
-```
-
-### PHASE 2: IMPLEMENTATION
-```
-[CODER MODE]
-
-Using the approved specification:
-1. Implement the feature
-   - Follow existing patterns in codebase
-   - Add comprehensive comments
-   - Include logging for all error paths
-   - No magic strings or hardcoded values
-
-2. Create test scaffolds
-   - Unit test file with structure
-   - Key test cases identified
-
-OUTPUT: Implementation code + test scaffolds
-GATE: Code must compile/parse without errors
-```
-
-### PHASE 3: TESTING
-```
-[TESTER MODE]
-
-Create and conceptualize tests:
-1. Positive test cases (happy path)
-2. Negative test cases (invalid inputs)
-3. Edge cases (boundaries, null, empty)
-4. Security probes (injection, XSS, auth bypass)
-
-OUTPUT: Test file with all cases
-GATE: All critical paths must have test coverage
-```
-
-### PHASE 4: VALIDATION
-```
-[GATE-KEEPER MODE] + [LAYER-CHECK MODE]
-
-STEP 1: BANNED PATTERN SCAN (BLOCKING)
-Run scan for: TODO, FIXME, PLACEHOLDER, STUB, MOCK, COMING SOON, NOT IMPLEMENTED
-ANY MATCH IN PRODUCTION CODE = IMMEDIATE REJECTION
-
-STEP 2: THREE-LAYER VALIDATION
-For each affected layer:
-
-DATABASE (if affected):
-□ Migration runs successfully
-□ Schema matches PRD data model
-□ Rollback tested
-□ Constraints and indexes in place
-
-BACKEND (if affected):
-□ All endpoints respond correctly
-□ Unit tests pass
-□ Integration tests pass
-□ Auth/authz enforced
-□ Input validation complete
-
-FRONTEND (if affected):
-□ Connected to REAL API (no mocks)
-□ All UI states implemented
-□ No placeholder text
-□ Accessibility verified
-
-STEP 3: ITERATION GATES
-□ Documentation complete
-□ Security scan clean
-□ Audit log entry created
-
-OUTPUT: Layer validation matrix + Gate status
-GATE: ALL affected layers must PASS, ALL iteration gates must PASS
-```
-
-### PHASE 4.5: SECURITY AUDIT
-```
-[SECURITY MODE]
-
-Mandatory security checks:
-1. No secrets in code (grep for passwords, api_key, secret)
-2. Input validation on all user inputs
-3. SQL injection prevention verified
-4. XSS prevention verified
-5. Auth tokens handled securely
-6. No sensitive data in logs
-7. CSRF protection in place
-
-OUTPUT: Security audit report
-GATE: Zero security violations allowed
-```
-
-### PHASE 5: DOCUMENTATION
-```
-[DOCS MODE]
-
-Create documentation:
-1. Feature purpose and usage
-2. API reference (if applicable)
-3. Code examples
-4. Known limitations
-
-OUTPUT: Documentation file
-```
-
-### PHASE 6: FINAL EVALUATION
-```
-[EVALUATOR MODE]
-
-Final review against BPSBS:
-1. Security compliance
-2. Code quality standards
-3. Test coverage
-4. Documentation completeness
-
-OUTPUT: Final verdict and any recommendations
-```
+The phases, gates, and delivery audit are `/forge`'s — see `/forge`. `/auto`'s role here is classification and dispatch, not re-implementing the pipeline.
 
 ---
 
@@ -415,25 +241,7 @@ Waiting for response...
 
 ## STORY LOOP
 
-When multiple stories exist, Auto Pilot loops through them:
-
-```
-FOR EACH story in dependency order:
-    IF story.status == TODO:
-        story.status = IN_PROGRESS
-        Execute PHASE 1-6 for this story
-        IF all phases pass:
-            story.status = DONE
-            Update INDEX.md
-        ELSE:
-            story.status = BLOCKED
-            Report blocker
-            Ask: Continue to next story or stop?
-
-    IF all stories DONE:
-        Run FINAL EVALUATION on complete feature
-        Generate feature completion report
-```
+Multi-story iteration for feature work is `/forge`'s responsibility, not `/auto`'s. When `/auto` dispatches a NEW_FEATURE / PRD_FEATURE to `/forge`, `/forge` loops through the generated stories in dependency order, gates each at every Anvil handoff, and produces the delivery audit and completion report. `/auto` does not run its own per-story phase loop.
 
 ---
 
@@ -446,18 +254,10 @@ User says:
 
 Auto Pilot executes:
 1. ✓ Classify: NEW_FEATURE (complex)
-2. ✓ PRD: Interrogate user, generate full PRD
-3. ✓ USER APPROVAL: Present PRD for sign-off
-4. ✓ STORIES: Generate 5 implementation stories
-5. ✓ STORY-001: Auth models → Architect → Code → Test → Gate → Docs
-6. ✓ STORY-002: Login API → Architect → Code → Test → Gate → Docs
-7. ✓ STORY-003: Logout → Architect → Code → Test → Gate → Docs
-8. ✓ STORY-004: Auth middleware → Architect → Code → Test → Gate → Docs
-9. ✓ STORY-005: Login UI → Architect → Code → Test → Gate → Docs
-10. ✓ EVALUATOR: Final BPSBS compliance check
-11. ✓ REPORT: Summary of all deliverables
+2. ✓ PRD: no PRD exists → run `/prd` to interrogate and generate it in genesis/ (user sign-off)
+3. ✓ Dispatch `/forge` — validates the PRD, generates stories, and runs the full gated pipeline (implement → Anvil gates → delivery audit → security → docs → harvest → debrief) for every story
 
-User receives: Complete, tested, documented authentication system with full PRD and story trail.
+User receives: Complete, tested, documented authentication system — with the same gates and delivery audit as a direct `/forge` run.
 
 ### Example 2: From Existing PRD
 
@@ -466,10 +266,7 @@ User says:
 
 Auto Pilot executes:
 1. ✓ Classify: PRD_FEATURE
-2. ✓ Load PRD (skip creation)
-3. ✓ STORIES: Generate or load existing stories
-4. ✓ Execute story loop
-5. ✓ REPORT
+2. ✓ Dispatch `/forge genesis/2026-01-16-user-auth.md` — PRD validation → stories → full gated pipeline → report
 
 ### Example 3: Simple Feature (Skip PRD)
 

--- a/.claude/commands/forge.md
+++ b/.claude/commands/forge.md
@@ -5,6 +5,8 @@ min_model: opus
 
 > The full pipeline: validate, implement, test, audit, and harvest — all in one command.
 
+> **Runtime note — two forges, one metaphor.** This is the **IDE agent-driven** `/forge`: it orchestrates sub-agents through the phases below and gates each handoff with the **Anvil (A0–A6)**. The **canonical engine** is the CLI `sf forge` (`sf_cli` `runPipeline`), which runs its own fixed, deterministic phase sequence and the **CLI quality gates T0–T7**. Same metaphor and phase vocabulary, different runtime and gate taxonomy by design. Use this skill inside an AI IDE; use `sf forge` for a self-contained CLI run.
+
 ---
 
 ## Usage

--- a/.copilot/custom-agents/auto.md
+++ b/.copilot/custom-agents/auto.md
@@ -55,194 +55,20 @@ IF input is NEW_FEATURE and no PRD exists:
 
 ---
 
-## FULL PIPELINE (NEW_FEATURE / PRD_FEATURE)
+## FULL PIPELINE (NEW_FEATURE / PRD_FEATURE) — dispatches to /forge
 
-Execute these phases sequentially. Do not proceed if a phase fails.
+`/auto` does not run its own feature pipeline. For NEW_FEATURE and PRD_FEATURE it ensures a PRD exists, then **dispatches to `/forge`**, which owns the canonical pipeline: PRD validation → story generation → per-story implementation → Anvil (A0–A6) gates at every handoff → delivery audit → security audit → knowledge harvest → debrief. `/auto` feature runs therefore get the same gates and delivery audit as a direct `/forge` run — not a separate, drifting copy of the pipeline.
 
-### PHASE 0: PRD CREATION (if needed)
 ```
-[PRD MODE]
+PRD_FEATURE  (a PRD path is given, or a PRD already exists in genesis/):
+    → /forge [prd-file]
 
-Check: Does a PRD exist for this feature?
-
-IF NO PRD EXISTS:
-    1. Run PRD Architect interrogation
-    2. Extract requirements from user
-    3. Generate full PRD document
-    4. Save to: genesis/[YYYY-MM-DD]-[feature-slug].md
-    5. Present PRD for user approval
-
-IF PRD EXISTS:
-    → Load PRD
-    → Verify status is APPROVED or IMPLEMENTING
-    → Proceed to Phase 0.5
-
-OUTPUT: Approved PRD document
-GATE: PRD must be complete and approved before proceeding
+NEW_FEATURE  (no PRD yet):
+    → /prd "description"        # create the PRD in genesis/ (per PRD Detection Logic above)
+    → /forge                    # then run the full pipeline
 ```
 
-### PHASE 0.5: STORY GENERATION (if needed)
-```
-[STORY MODE]
-
-Check: Do implementation stories exist for this PRD?
-
-IF NO STORIES EXIST:
-    1. Parse PRD for user stories and functional requirements
-    2. Group into implementation stories
-    3. Generate hyper-detailed story files
-    4. Create dependency graph
-    5. Save to: docs/stories/[prd-slug]/
-
-IF STORIES EXIST:
-    → Load story index
-    → Identify next TODO story
-    → Check dependencies are satisfied
-
-OUTPUT: Story set with INDEX.md
-GATE: At least one story must be ready for implementation
-```
-
-### PHASE 1: REQUIREMENTS & ARCHITECTURE
-```
-[ARCHITECT MODE]
-
-Using PRD and current story as context:
-
-1. Validate story completeness
-   - Clear inputs and outputs
-   - Data models required
-   - User roles and permissions
-   - Error cases to handle
-
-2. Security review
-   - Authentication requirements
-   - Input validation needs
-   - Data exposure risks
-
-3. Architecture decision
-   - Components to create/modify
-   - Dependencies needed
-   - Integration points
-
-OUTPUT: Approved architecture for current story
-GATE: Architecture must align with PRD and story requirements
-```
-
-### PHASE 2: IMPLEMENTATION
-```
-[CODER MODE]
-
-Using the approved specification:
-1. Implement the feature
-   - Follow existing patterns in codebase
-   - Add comprehensive comments
-   - Include logging for all error paths
-   - No magic strings or hardcoded values
-
-2. Create test scaffolds
-   - Unit test file with structure
-   - Key test cases identified
-
-OUTPUT: Implementation code + test scaffolds
-GATE: Code must compile/parse without errors
-```
-
-### PHASE 3: TESTING
-```
-[TESTER MODE]
-
-Create and conceptualize tests:
-1. Positive test cases (happy path)
-2. Negative test cases (invalid inputs)
-3. Edge cases (boundaries, null, empty)
-4. Security probes (injection, XSS, auth bypass)
-
-OUTPUT: Test file with all cases
-GATE: All critical paths must have test coverage
-```
-
-### PHASE 4: VALIDATION
-```
-[GATE-KEEPER MODE] + [LAYER-CHECK MODE]
-
-STEP 1: BANNED PATTERN SCAN (BLOCKING)
-Run scan for: TODO, FIXME, PLACEHOLDER, STUB, MOCK, COMING SOON, NOT IMPLEMENTED
-ANY MATCH IN PRODUCTION CODE = IMMEDIATE REJECTION
-
-STEP 2: THREE-LAYER VALIDATION
-For each affected layer:
-
-DATABASE (if affected):
-□ Migration runs successfully
-□ Schema matches PRD data model
-□ Rollback tested
-□ Constraints and indexes in place
-
-BACKEND (if affected):
-□ All endpoints respond correctly
-□ Unit tests pass
-□ Integration tests pass
-□ Auth/authz enforced
-□ Input validation complete
-
-FRONTEND (if affected):
-□ Connected to REAL API (no mocks)
-□ All UI states implemented
-□ No placeholder text
-□ Accessibility verified
-
-STEP 3: ITERATION GATES
-□ Documentation complete
-□ Security scan clean
-□ Audit log entry created
-
-OUTPUT: Layer validation matrix + Gate status
-GATE: ALL affected layers must PASS, ALL iteration gates must PASS
-```
-
-### PHASE 4.5: SECURITY AUDIT
-```
-[SECURITY MODE]
-
-Mandatory security checks:
-1. No secrets in code (grep for passwords, api_key, secret)
-2. Input validation on all user inputs
-3. SQL injection prevention verified
-4. XSS prevention verified
-5. Auth tokens handled securely
-6. No sensitive data in logs
-7. CSRF protection in place
-
-OUTPUT: Security audit report
-GATE: Zero security violations allowed
-```
-
-### PHASE 5: DOCUMENTATION
-```
-[DOCS MODE]
-
-Create documentation:
-1. Feature purpose and usage
-2. API reference (if applicable)
-3. Code examples
-4. Known limitations
-
-OUTPUT: Documentation file
-```
-
-### PHASE 6: FINAL EVALUATION
-```
-[EVALUATOR MODE]
-
-Final review against BPSBS:
-1. Security compliance
-2. Code quality standards
-3. Test coverage
-4. Documentation completeness
-
-OUTPUT: Final verdict and any recommendations
-```
+The phases, gates, and delivery audit are `/forge`'s — see `/forge`. `/auto`'s role here is classification and dispatch, not re-implementing the pipeline.
 
 ---
 
@@ -424,25 +250,7 @@ Waiting for response...
 
 ## STORY LOOP
 
-When multiple stories exist, Auto Pilot loops through them:
-
-```
-FOR EACH story in dependency order:
-    IF story.status == TODO:
-        story.status = IN_PROGRESS
-        Execute PHASE 1-6 for this story
-        IF all phases pass:
-            story.status = DONE
-            Update INDEX.md
-        ELSE:
-            story.status = BLOCKED
-            Report blocker
-            Ask: Continue to next story or stop?
-
-    IF all stories DONE:
-        Run FINAL EVALUATION on complete feature
-        Generate feature completion report
-```
+Multi-story iteration for feature work is `/forge`'s responsibility, not `/auto`'s. When `/auto` dispatches a NEW_FEATURE / PRD_FEATURE to `/forge`, `/forge` loops through the generated stories in dependency order, gates each at every Anvil handoff, and produces the delivery audit and completion report. `/auto` does not run its own per-story phase loop.
 
 ---
 
@@ -455,18 +263,10 @@ User says:
 
 Auto Pilot executes:
 1. ✓ Classify: NEW_FEATURE (complex)
-2. ✓ PRD: Interrogate user, generate full PRD
-3. ✓ USER APPROVAL: Present PRD for sign-off
-4. ✓ STORIES: Generate 5 implementation stories
-5. ✓ STORY-001: Auth models → Architect → Code → Test → Gate → Docs
-6. ✓ STORY-002: Login API → Architect → Code → Test → Gate → Docs
-7. ✓ STORY-003: Logout → Architect → Code → Test → Gate → Docs
-8. ✓ STORY-004: Auth middleware → Architect → Code → Test → Gate → Docs
-9. ✓ STORY-005: Login UI → Architect → Code → Test → Gate → Docs
-10. ✓ EVALUATOR: Final BPSBS compliance check
-11. ✓ REPORT: Summary of all deliverables
+2. ✓ PRD: no PRD exists → run `/prd` to interrogate and generate it in genesis/ (user sign-off)
+3. ✓ Dispatch `/forge` — validates the PRD, generates stories, and runs the full gated pipeline (implement → Anvil gates → delivery audit → security → docs → harvest → debrief) for every story
 
-User receives: Complete, tested, documented authentication system with full PRD and story trail.
+User receives: Complete, tested, documented authentication system — with the same gates and delivery audit as a direct `/forge` run.
 
 ### Example 2: From Existing PRD
 
@@ -475,10 +275,7 @@ User says:
 
 Auto Pilot executes:
 1. ✓ Classify: PRD_FEATURE
-2. ✓ Load PRD (skip creation)
-3. ✓ STORIES: Generate or load existing stories
-4. ✓ Execute story loop
-5. ✓ REPORT
+2. ✓ Dispatch `/forge genesis/2026-01-16-user-auth.md` — PRD validation → stories → full gated pipeline → report
 
 ### Example 3: Simple Feature (Skip PRD)
 

--- a/.copilot/custom-agents/forge.md
+++ b/.copilot/custom-agents/forge.md
@@ -14,6 +14,8 @@ min_model: opus
 
 > The full pipeline: validate, implement, test, audit, and harvest — all in one command.
 
+> **Runtime note — two forges, one metaphor.** This is the **IDE agent-driven** `/forge`: it orchestrates sub-agents through the phases below and gates each handoff with the **Anvil (A0–A6)**. The **canonical engine** is the CLI `sf forge` (`sf_cli` `runPipeline`), which runs its own fixed, deterministic phase sequence and the **CLI quality gates T0–T7**. Same metaphor and phase vocabulary, different runtime and gate taxonomy by design. Use this skill inside an AI IDE; use `sf forge` for a self-contained CLI run.
+
 ---
 
 ## Usage

--- a/.cursor/rules/auto.md
+++ b/.cursor/rules/auto.md
@@ -57,194 +57,20 @@ IF input is NEW_FEATURE and no PRD exists:
 
 ---
 
-## FULL PIPELINE (NEW_FEATURE / PRD_FEATURE)
+## FULL PIPELINE (NEW_FEATURE / PRD_FEATURE) — dispatches to /forge
 
-Execute these phases sequentially. Do not proceed if a phase fails.
+`/auto` does not run its own feature pipeline. For NEW_FEATURE and PRD_FEATURE it ensures a PRD exists, then **dispatches to `/forge`**, which owns the canonical pipeline: PRD validation → story generation → per-story implementation → Anvil (A0–A6) gates at every handoff → delivery audit → security audit → knowledge harvest → debrief. `/auto` feature runs therefore get the same gates and delivery audit as a direct `/forge` run — not a separate, drifting copy of the pipeline.
 
-### PHASE 0: PRD CREATION (if needed)
 ```
-[PRD MODE]
+PRD_FEATURE  (a PRD path is given, or a PRD already exists in genesis/):
+    → /forge [prd-file]
 
-Check: Does a PRD exist for this feature?
-
-IF NO PRD EXISTS:
-    1. Run PRD Architect interrogation
-    2. Extract requirements from user
-    3. Generate full PRD document
-    4. Save to: genesis/[YYYY-MM-DD]-[feature-slug].md
-    5. Present PRD for user approval
-
-IF PRD EXISTS:
-    → Load PRD
-    → Verify status is APPROVED or IMPLEMENTING
-    → Proceed to Phase 0.5
-
-OUTPUT: Approved PRD document
-GATE: PRD must be complete and approved before proceeding
+NEW_FEATURE  (no PRD yet):
+    → /prd "description"        # create the PRD in genesis/ (per PRD Detection Logic above)
+    → /forge                    # then run the full pipeline
 ```
 
-### PHASE 0.5: STORY GENERATION (if needed)
-```
-[STORY MODE]
-
-Check: Do implementation stories exist for this PRD?
-
-IF NO STORIES EXIST:
-    1. Parse PRD for user stories and functional requirements
-    2. Group into implementation stories
-    3. Generate hyper-detailed story files
-    4. Create dependency graph
-    5. Save to: docs/stories/[prd-slug]/
-
-IF STORIES EXIST:
-    → Load story index
-    → Identify next TODO story
-    → Check dependencies are satisfied
-
-OUTPUT: Story set with INDEX.md
-GATE: At least one story must be ready for implementation
-```
-
-### PHASE 1: REQUIREMENTS & ARCHITECTURE
-```
-[ARCHITECT MODE]
-
-Using PRD and current story as context:
-
-1. Validate story completeness
-   - Clear inputs and outputs
-   - Data models required
-   - User roles and permissions
-   - Error cases to handle
-
-2. Security review
-   - Authentication requirements
-   - Input validation needs
-   - Data exposure risks
-
-3. Architecture decision
-   - Components to create/modify
-   - Dependencies needed
-   - Integration points
-
-OUTPUT: Approved architecture for current story
-GATE: Architecture must align with PRD and story requirements
-```
-
-### PHASE 2: IMPLEMENTATION
-```
-[CODER MODE]
-
-Using the approved specification:
-1. Implement the feature
-   - Follow existing patterns in codebase
-   - Add comprehensive comments
-   - Include logging for all error paths
-   - No magic strings or hardcoded values
-
-2. Create test scaffolds
-   - Unit test file with structure
-   - Key test cases identified
-
-OUTPUT: Implementation code + test scaffolds
-GATE: Code must compile/parse without errors
-```
-
-### PHASE 3: TESTING
-```
-[TESTER MODE]
-
-Create and conceptualize tests:
-1. Positive test cases (happy path)
-2. Negative test cases (invalid inputs)
-3. Edge cases (boundaries, null, empty)
-4. Security probes (injection, XSS, auth bypass)
-
-OUTPUT: Test file with all cases
-GATE: All critical paths must have test coverage
-```
-
-### PHASE 4: VALIDATION
-```
-[GATE-KEEPER MODE] + [LAYER-CHECK MODE]
-
-STEP 1: BANNED PATTERN SCAN (BLOCKING)
-Run scan for: TODO, FIXME, PLACEHOLDER, STUB, MOCK, COMING SOON, NOT IMPLEMENTED
-ANY MATCH IN PRODUCTION CODE = IMMEDIATE REJECTION
-
-STEP 2: THREE-LAYER VALIDATION
-For each affected layer:
-
-DATABASE (if affected):
-□ Migration runs successfully
-□ Schema matches PRD data model
-□ Rollback tested
-□ Constraints and indexes in place
-
-BACKEND (if affected):
-□ All endpoints respond correctly
-□ Unit tests pass
-□ Integration tests pass
-□ Auth/authz enforced
-□ Input validation complete
-
-FRONTEND (if affected):
-□ Connected to REAL API (no mocks)
-□ All UI states implemented
-□ No placeholder text
-□ Accessibility verified
-
-STEP 3: ITERATION GATES
-□ Documentation complete
-□ Security scan clean
-□ Audit log entry created
-
-OUTPUT: Layer validation matrix + Gate status
-GATE: ALL affected layers must PASS, ALL iteration gates must PASS
-```
-
-### PHASE 4.5: SECURITY AUDIT
-```
-[SECURITY MODE]
-
-Mandatory security checks:
-1. No secrets in code (grep for passwords, api_key, secret)
-2. Input validation on all user inputs
-3. SQL injection prevention verified
-4. XSS prevention verified
-5. Auth tokens handled securely
-6. No sensitive data in logs
-7. CSRF protection in place
-
-OUTPUT: Security audit report
-GATE: Zero security violations allowed
-```
-
-### PHASE 5: DOCUMENTATION
-```
-[DOCS MODE]
-
-Create documentation:
-1. Feature purpose and usage
-2. API reference (if applicable)
-3. Code examples
-4. Known limitations
-
-OUTPUT: Documentation file
-```
-
-### PHASE 6: FINAL EVALUATION
-```
-[EVALUATOR MODE]
-
-Final review against BPSBS:
-1. Security compliance
-2. Code quality standards
-3. Test coverage
-4. Documentation completeness
-
-OUTPUT: Final verdict and any recommendations
-```
+The phases, gates, and delivery audit are `/forge`'s — see `/forge`. `/auto`'s role here is classification and dispatch, not re-implementing the pipeline.
 
 ---
 
@@ -426,25 +252,7 @@ Waiting for response...
 
 ## STORY LOOP
 
-When multiple stories exist, Auto Pilot loops through them:
-
-```
-FOR EACH story in dependency order:
-    IF story.status == TODO:
-        story.status = IN_PROGRESS
-        Execute PHASE 1-6 for this story
-        IF all phases pass:
-            story.status = DONE
-            Update INDEX.md
-        ELSE:
-            story.status = BLOCKED
-            Report blocker
-            Ask: Continue to next story or stop?
-
-    IF all stories DONE:
-        Run FINAL EVALUATION on complete feature
-        Generate feature completion report
-```
+Multi-story iteration for feature work is `/forge`'s responsibility, not `/auto`'s. When `/auto` dispatches a NEW_FEATURE / PRD_FEATURE to `/forge`, `/forge` loops through the generated stories in dependency order, gates each at every Anvil handoff, and produces the delivery audit and completion report. `/auto` does not run its own per-story phase loop.
 
 ---
 
@@ -457,18 +265,10 @@ User says:
 
 Auto Pilot executes:
 1. ✓ Classify: NEW_FEATURE (complex)
-2. ✓ PRD: Interrogate user, generate full PRD
-3. ✓ USER APPROVAL: Present PRD for sign-off
-4. ✓ STORIES: Generate 5 implementation stories
-5. ✓ STORY-001: Auth models → Architect → Code → Test → Gate → Docs
-6. ✓ STORY-002: Login API → Architect → Code → Test → Gate → Docs
-7. ✓ STORY-003: Logout → Architect → Code → Test → Gate → Docs
-8. ✓ STORY-004: Auth middleware → Architect → Code → Test → Gate → Docs
-9. ✓ STORY-005: Login UI → Architect → Code → Test → Gate → Docs
-10. ✓ EVALUATOR: Final BPSBS compliance check
-11. ✓ REPORT: Summary of all deliverables
+2. ✓ PRD: no PRD exists → run `/prd` to interrogate and generate it in genesis/ (user sign-off)
+3. ✓ Dispatch `/forge` — validates the PRD, generates stories, and runs the full gated pipeline (implement → Anvil gates → delivery audit → security → docs → harvest → debrief) for every story
 
-User receives: Complete, tested, documented authentication system with full PRD and story trail.
+User receives: Complete, tested, documented authentication system — with the same gates and delivery audit as a direct `/forge` run.
 
 ### Example 2: From Existing PRD
 
@@ -477,10 +277,7 @@ User says:
 
 Auto Pilot executes:
 1. ✓ Classify: PRD_FEATURE
-2. ✓ Load PRD (skip creation)
-3. ✓ STORIES: Generate or load existing stories
-4. ✓ Execute story loop
-5. ✓ REPORT
+2. ✓ Dispatch `/forge genesis/2026-01-16-user-auth.md` — PRD validation → stories → full gated pipeline → report
 
 ### Example 3: Simple Feature (Skip PRD)
 

--- a/.cursor/rules/forge.md
+++ b/.cursor/rules/forge.md
@@ -16,6 +16,8 @@ min_model: opus
 
 > The full pipeline: validate, implement, test, audit, and harvest — all in one command.
 
+> **Runtime note — two forges, one metaphor.** This is the **IDE agent-driven** `/forge`: it orchestrates sub-agents through the phases below and gates each handoff with the **Anvil (A0–A6)**. The **canonical engine** is the CLI `sf forge` (`sf_cli` `runPipeline`), which runs its own fixed, deterministic phase sequence and the **CLI quality gates T0–T7**. Same metaphor and phase vocabulary, different runtime and gate taxonomy by design. Use this skill inside an AI IDE; use `sf forge` for a self-contained CLI run.
+
 ---
 
 ## Usage

--- a/.gemini/skills/auto.md
+++ b/.gemini/skills/auto.md
@@ -52,194 +52,20 @@ IF input is NEW_FEATURE and no PRD exists:
 
 ---
 
-## FULL PIPELINE (NEW_FEATURE / PRD_FEATURE)
+## FULL PIPELINE (NEW_FEATURE / PRD_FEATURE) — dispatches to /forge
 
-Execute these phases sequentially. Do not proceed if a phase fails.
+`/auto` does not run its own feature pipeline. For NEW_FEATURE and PRD_FEATURE it ensures a PRD exists, then **dispatches to `/forge`**, which owns the canonical pipeline: PRD validation → story generation → per-story implementation → Anvil (A0–A6) gates at every handoff → delivery audit → security audit → knowledge harvest → debrief. `/auto` feature runs therefore get the same gates and delivery audit as a direct `/forge` run — not a separate, drifting copy of the pipeline.
 
-### PHASE 0: PRD CREATION (if needed)
 ```
-[PRD MODE]
+PRD_FEATURE  (a PRD path is given, or a PRD already exists in genesis/):
+    → /forge [prd-file]
 
-Check: Does a PRD exist for this feature?
-
-IF NO PRD EXISTS:
-    1. Run PRD Architect interrogation
-    2. Extract requirements from user
-    3. Generate full PRD document
-    4. Save to: genesis/[YYYY-MM-DD]-[feature-slug].md
-    5. Present PRD for user approval
-
-IF PRD EXISTS:
-    → Load PRD
-    → Verify status is APPROVED or IMPLEMENTING
-    → Proceed to Phase 0.5
-
-OUTPUT: Approved PRD document
-GATE: PRD must be complete and approved before proceeding
+NEW_FEATURE  (no PRD yet):
+    → /prd "description"        # create the PRD in genesis/ (per PRD Detection Logic above)
+    → /forge                    # then run the full pipeline
 ```
 
-### PHASE 0.5: STORY GENERATION (if needed)
-```
-[STORY MODE]
-
-Check: Do implementation stories exist for this PRD?
-
-IF NO STORIES EXIST:
-    1. Parse PRD for user stories and functional requirements
-    2. Group into implementation stories
-    3. Generate hyper-detailed story files
-    4. Create dependency graph
-    5. Save to: docs/stories/[prd-slug]/
-
-IF STORIES EXIST:
-    → Load story index
-    → Identify next TODO story
-    → Check dependencies are satisfied
-
-OUTPUT: Story set with INDEX.md
-GATE: At least one story must be ready for implementation
-```
-
-### PHASE 1: REQUIREMENTS & ARCHITECTURE
-```
-[ARCHITECT MODE]
-
-Using PRD and current story as context:
-
-1. Validate story completeness
-   - Clear inputs and outputs
-   - Data models required
-   - User roles and permissions
-   - Error cases to handle
-
-2. Security review
-   - Authentication requirements
-   - Input validation needs
-   - Data exposure risks
-
-3. Architecture decision
-   - Components to create/modify
-   - Dependencies needed
-   - Integration points
-
-OUTPUT: Approved architecture for current story
-GATE: Architecture must align with PRD and story requirements
-```
-
-### PHASE 2: IMPLEMENTATION
-```
-[CODER MODE]
-
-Using the approved specification:
-1. Implement the feature
-   - Follow existing patterns in codebase
-   - Add comprehensive comments
-   - Include logging for all error paths
-   - No magic strings or hardcoded values
-
-2. Create test scaffolds
-   - Unit test file with structure
-   - Key test cases identified
-
-OUTPUT: Implementation code + test scaffolds
-GATE: Code must compile/parse without errors
-```
-
-### PHASE 3: TESTING
-```
-[TESTER MODE]
-
-Create and conceptualize tests:
-1. Positive test cases (happy path)
-2. Negative test cases (invalid inputs)
-3. Edge cases (boundaries, null, empty)
-4. Security probes (injection, XSS, auth bypass)
-
-OUTPUT: Test file with all cases
-GATE: All critical paths must have test coverage
-```
-
-### PHASE 4: VALIDATION
-```
-[GATE-KEEPER MODE] + [LAYER-CHECK MODE]
-
-STEP 1: BANNED PATTERN SCAN (BLOCKING)
-Run scan for: TODO, FIXME, PLACEHOLDER, STUB, MOCK, COMING SOON, NOT IMPLEMENTED
-ANY MATCH IN PRODUCTION CODE = IMMEDIATE REJECTION
-
-STEP 2: THREE-LAYER VALIDATION
-For each affected layer:
-
-DATABASE (if affected):
-□ Migration runs successfully
-□ Schema matches PRD data model
-□ Rollback tested
-□ Constraints and indexes in place
-
-BACKEND (if affected):
-□ All endpoints respond correctly
-□ Unit tests pass
-□ Integration tests pass
-□ Auth/authz enforced
-□ Input validation complete
-
-FRONTEND (if affected):
-□ Connected to REAL API (no mocks)
-□ All UI states implemented
-□ No placeholder text
-□ Accessibility verified
-
-STEP 3: ITERATION GATES
-□ Documentation complete
-□ Security scan clean
-□ Audit log entry created
-
-OUTPUT: Layer validation matrix + Gate status
-GATE: ALL affected layers must PASS, ALL iteration gates must PASS
-```
-
-### PHASE 4.5: SECURITY AUDIT
-```
-[SECURITY MODE]
-
-Mandatory security checks:
-1. No secrets in code (grep for passwords, api_key, secret)
-2. Input validation on all user inputs
-3. SQL injection prevention verified
-4. XSS prevention verified
-5. Auth tokens handled securely
-6. No sensitive data in logs
-7. CSRF protection in place
-
-OUTPUT: Security audit report
-GATE: Zero security violations allowed
-```
-
-### PHASE 5: DOCUMENTATION
-```
-[DOCS MODE]
-
-Create documentation:
-1. Feature purpose and usage
-2. API reference (if applicable)
-3. Code examples
-4. Known limitations
-
-OUTPUT: Documentation file
-```
-
-### PHASE 6: FINAL EVALUATION
-```
-[EVALUATOR MODE]
-
-Final review against BPSBS:
-1. Security compliance
-2. Code quality standards
-3. Test coverage
-4. Documentation completeness
-
-OUTPUT: Final verdict and any recommendations
-```
+The phases, gates, and delivery audit are `/forge`'s — see `/forge`. `/auto`'s role here is classification and dispatch, not re-implementing the pipeline.
 
 ---
 
@@ -421,25 +247,7 @@ Waiting for response...
 
 ## STORY LOOP
 
-When multiple stories exist, Auto Pilot loops through them:
-
-```
-FOR EACH story in dependency order:
-    IF story.status == TODO:
-        story.status = IN_PROGRESS
-        Execute PHASE 1-6 for this story
-        IF all phases pass:
-            story.status = DONE
-            Update INDEX.md
-        ELSE:
-            story.status = BLOCKED
-            Report blocker
-            Ask: Continue to next story or stop?
-
-    IF all stories DONE:
-        Run FINAL EVALUATION on complete feature
-        Generate feature completion report
-```
+Multi-story iteration for feature work is `/forge`'s responsibility, not `/auto`'s. When `/auto` dispatches a NEW_FEATURE / PRD_FEATURE to `/forge`, `/forge` loops through the generated stories in dependency order, gates each at every Anvil handoff, and produces the delivery audit and completion report. `/auto` does not run its own per-story phase loop.
 
 ---
 
@@ -452,18 +260,10 @@ User says:
 
 Auto Pilot executes:
 1. ✓ Classify: NEW_FEATURE (complex)
-2. ✓ PRD: Interrogate user, generate full PRD
-3. ✓ USER APPROVAL: Present PRD for sign-off
-4. ✓ STORIES: Generate 5 implementation stories
-5. ✓ STORY-001: Auth models → Architect → Code → Test → Gate → Docs
-6. ✓ STORY-002: Login API → Architect → Code → Test → Gate → Docs
-7. ✓ STORY-003: Logout → Architect → Code → Test → Gate → Docs
-8. ✓ STORY-004: Auth middleware → Architect → Code → Test → Gate → Docs
-9. ✓ STORY-005: Login UI → Architect → Code → Test → Gate → Docs
-10. ✓ EVALUATOR: Final BPSBS compliance check
-11. ✓ REPORT: Summary of all deliverables
+2. ✓ PRD: no PRD exists → run `/prd` to interrogate and generate it in genesis/ (user sign-off)
+3. ✓ Dispatch `/forge` — validates the PRD, generates stories, and runs the full gated pipeline (implement → Anvil gates → delivery audit → security → docs → harvest → debrief) for every story
 
-User receives: Complete, tested, documented authentication system with full PRD and story trail.
+User receives: Complete, tested, documented authentication system — with the same gates and delivery audit as a direct `/forge` run.
 
 ### Example 2: From Existing PRD
 
@@ -472,10 +272,7 @@ User says:
 
 Auto Pilot executes:
 1. ✓ Classify: PRD_FEATURE
-2. ✓ Load PRD (skip creation)
-3. ✓ STORIES: Generate or load existing stories
-4. ✓ Execute story loop
-5. ✓ REPORT
+2. ✓ Dispatch `/forge genesis/2026-01-16-user-auth.md` — PRD validation → stories → full gated pipeline → report
 
 ### Example 3: Simple Feature (Skip PRD)
 

--- a/.gemini/skills/forge.md
+++ b/.gemini/skills/forge.md
@@ -11,6 +11,8 @@ min_model: opus
 
 > The full pipeline: validate, implement, test, audit, and harvest — all in one command.
 
+> **Runtime note — two forges, one metaphor.** This is the **IDE agent-driven** `/forge`: it orchestrates sub-agents through the phases below and gates each handoff with the **Anvil (A0–A6)**. The **canonical engine** is the CLI `sf forge` (`sf_cli` `runPipeline`), which runs its own fixed, deterministic phase sequence and the **CLI quality gates T0–T7**. Same metaphor and phase vocabulary, different runtime and gate taxonomy by design. Use this skill inside an AI IDE; use `sf forge` for a self-contained CLI run.
+
 ---
 
 ## Usage


### PR DESCRIPTION
Approved execution pass over the audit's below-the-line consolidation findings (§1.3–§1.6). **2 implemented, 2 skipped** — skips are because a faithful implementation would require net-new capability, which the pass explicitly forbids. Refinement only; no new features/commands/files.

## Implemented

### §1.3 — Reconcile the two /forge (`3f8f05e`)
Adds a **Runtime note** to the `/forge` skill declaring the CLI `sf forge` (`sf_cli` `runPipeline`) the canonical deterministic engine and this skill the IDE agent-driven variant, naming both gate taxonomies (skill = Anvil A0–A6, CLI = quality gates T0–T7). Both engines kept; **doc-only, no behavior change.** Smallest change achieving the finding's stated minimum.

### §1.5 — /auto feature branch → /forge (`725b275`) ⚠️ approved behavioral delta
Replaces `/auto`'s private FULL PIPELINE (PHASE 0–6: PRD→Stories→Arch→Impl→Test→Validate→Security→Docs→Eval) with a dispatch: `PRD_FEATURE → /forge [prd]`, `NEW_FEATURE → /prd` then `/forge`. The classifier and the BUG_FIX/REFACTOR branches are untouched; the STORY LOOP and QUICK START examples were updated for coherence (they described the removed phases).

**Behavioral delta (approved):** `/auto` feature runs now execute `/forge`'s real Anvil gates + delivery audit instead of the lighter in-persona gates. `auto.md` 519 → 316 lines.

## Skipped (need net-new capability — out of scope)

- **§1.4 /quick + /hotfix → /feature profiles** — a faithful deferral needs new `--quick`/`--hotfix` profile flags on `/feature` (existing `--lite`/`--no-commit` can't reproduce quick's max-3 testloop + security-scan + no-docs, or hotfix's Semgrep-hard-block + smoke-only + follow-up + audit). They already read as reduced-`/feature` with cross-references, so a doc-only reframe changes nothing.
- **§1.6 /orchestrate → /delegate profile** — not "delegate + a toggle": different personas (`agent-orchestrator` vs `project-orchestrator`) and different decomposition models (recursive vs fixed NASAB 7-phase). Making it a profile needs a new NASAB-mode capability on `/delegate`, or rewriting orchestrate onto delegate's model — a behavior change that risks the load-bearing NASAB gate semantics.

## Verification
- Platform sync integrity **52/52** (0 drift, 0 missing) after each finding; all prompt changes regenerated across the 5 generated platforms.
- No CLI code touched. `/auto` is IDE-only (no `sf auto`), so no CLI/IDE parity to reconcile.
- One commit per finding; no unrelated changes swept in.

| Finding | Status |
|---|---|
| §1.3 Reconcile the two /forge | ✅ Done |
| §1.4 /quick + /hotfix → /feature profiles | ⏭️ Skipped (needs new /feature flags) |
| §1.5 /auto feature branch → /forge | ✅ Done (behavioral delta) |
| §1.6 /orchestrate → /delegate profile | ⏭️ Skipped (needs new /delegate NASAB mode) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
