### PR TITLE
chore(genesis): reconcile stale PRD statuses → COMPLETED (12 shipped features)

### DIFF
--- a/genesis/2026-02-20-autonomous-developer-loop.md
+++ b/genesis/2026-02-20-autonomous-developer-loop.md
@@ -4,7 +4,7 @@
 prd_id: autonomous-developer-loop
 title: Autonomous Developer Loop + Knowledge Sync
 version: 1.0
-status: APPROVED
+status: COMPLETED
 created: 2026-02-20
 author: SBS + Claude
 last_updated: 2026-02-20

--- a/genesis/2026-02-27-local-first-development.md
+++ b/genesis/2026-02-27-local-first-development.md
@@ -4,7 +4,7 @@
 prd_id: local-first-development
 title: Local-First Development
 version: 1.0
-status: IMPLEMENTED
+status: COMPLETED
 created: 2026-02-27
 author: SkillFoundry Team
 last_updated: 2026-02-27

--- a/genesis/2026-03-12-native-debugger-integration.md
+++ b/genesis/2026-03-12-native-debugger-integration.md
@@ -4,7 +4,7 @@
 prd_id: native-debugger-integration
 title: Native Debugger Integration — Runtime State Inspection for AI Agents
 version: 1.0
-status: DRAFT
+status: COMPLETED
 created: 2026-03-12
 author: redacted-user
 last_updated: 2026-03-12

--- a/genesis/2026-03-15-semgrep-security-integration.md
+++ b/genesis/2026-03-15-semgrep-security-integration.md
@@ -4,7 +4,7 @@
 prd_id: semgrep-security-integration
 title: Semgrep Security Integration
 version: 1.0
-status: DRAFT
+status: COMPLETED
 created: 2026-03-15
 author: SkillFoundry Team
 last_updated: 2026-03-15

--- a/genesis/2026-03-15-swarm-intelligence-patterns.md
+++ b/genesis/2026-03-15-swarm-intelligence-patterns.md
@@ -4,7 +4,7 @@
 prd_id: swarm-intelligence-patterns
 title: Swarm Intelligence Patterns Integration
 version: 1.0
-status: DRAFT
+status: COMPLETED
 created: 2026-03-15
 author: SBS
 last_updated: 2026-03-15

--- a/genesis/2026-03-15-vscode-extension.md
+++ b/genesis/2026-03-15-vscode-extension.md
@@ -4,7 +4,7 @@
 prd_id: vscode-extension
 title: SkillFoundry VS Code Extension
 version: 1.0
-status: DRAFT
+status: COMPLETED
 created: 2026-03-15
 author: SBS + PRD Architect
 last_updated: 2026-03-15

--- a/genesis/2026-03-25-industry-knowledge-engine.md
+++ b/genesis/2026-03-25-industry-knowledge-engine.md
@@ -2,7 +2,7 @@
 
 **Date**: 2026-03-25
 **Author**: redacted-user + Claude
-**Status**: DRAFT
+**Status**: COMPLETED
 **Priority**: HIGH
 **Estimated Effort**: Large (3 phases)
 

--- a/genesis/2026-03-28-skillfoundry-v3-mcp-agent-server.md
+++ b/genesis/2026-03-28-skillfoundry-v3-mcp-agent-server.md
@@ -4,7 +4,7 @@
 prd_id: skillfoundry-v3-mcp-agent-server
 title: SkillFoundry v3 — MCP Agent Server
 version: 1.0
-status: DRAFT
+status: COMPLETED
 created: 2026-03-28
 author: redacted-user + PRD Architect
 last_updated: 2026-03-28

--- a/genesis/2026-05-05-specter-security-engine.md
+++ b/genesis/2026-05-05-specter-security-engine.md
@@ -4,7 +4,7 @@
 prd_id: specter-security-engine
 title: 'Specter' Security Engine
 version: 1.0
-status: DRAFT
+status: COMPLETED
 created: 2026-05-05
 author: Gemini CLI
 last_updated: 2026-05-05

--- a/genesis/2026-05-06-sf-orchestrator.md
+++ b/genesis/2026-05-06-sf-orchestrator.md
@@ -4,7 +4,7 @@
 prd_id: sf-orchestrator
 title: SkillFoundry Web Orchestrator
 version: 1.0
-status: READY
+status: COMPLETED
 created: 2026-05-06
 author: samibs
 last_updated: 2026-05-06

--- a/genesis/2026-05-08-folder-state-and-checkbox-reconciler.md
+++ b/genesis/2026-05-08-folder-state-and-checkbox-reconciler.md
@@ -4,7 +4,7 @@
 prd_id: folder-state-and-checkbox-reconciler
 title: Story Folder State Machine & Checkbox Reconciler
 version: 1.0
-status: DRAFT
+status: COMPLETED
 created: 2026-05-08
 author: redacted-user
 last_updated: 2026-05-08

--- a/genesis/2026-07-10-domain-expert-synthesis.md
+++ b/genesis/2026-07-10-domain-expert-synthesis.md
@@ -2,7 +2,7 @@
 prd_id: domain-expert-synthesis
 title: Domain Expert Synthesis
 version: 1.4
-status: READY
+status: COMPLETED
 created: 2026-07-10
 author: samibs
 last_updated: 2026-07-11


### PR DESCRIPTION
Surfaced by `/go` discovery: `genesis/` (the framework's own build archive) had shipped features still marked DRAFT/READY/APPROVED/IMPLEMENTED.

Marked **COMPLETED only where a deliverable was verified present** (12 PRDs) — e.g. domain-expert-synthesis (v5.26.0 scripts), sf-orchestrator (mcp-server), semgrep (config/semgrep-rules), /debug, /swarm, packs/, move-story.sh. Normalized `IMPLEMENTED` → canonical `COMPLETED`.

**Left DRAFT** where evidence was weak (local-vector-memory, dynamic-skill-optimization, deployment-preflight-gate, tenant-isolation-auditor) rather than guess — the ~24 remaining DRAFTs are unverified/aspirational specs.

Frontmatter-only change; `COMPLETED` is the canonical done-status `/go` reads and it clears the stale DRAFT lint warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)