### PR TITLE
chore(genesis): framework-hardening READY → COMPLETED (shipped v2.0.78)

### DIFF
--- a/genesis/2026-03-27-framework-hardening.md
+++ b/genesis/2026-03-27-framework-hardening.md
@@ -2,7 +2,7 @@
 
 **Date**: 2026-03-27
 **Author**: redacted-user + Claude
-**Status**: READY
+**Status**: COMPLETED
 **Priority**: CRITICAL
 **Estimated Effort**: Very Large (7 phases, multi-session)
 


### PR DESCRIPTION
The last PRD `/go` discovery reported as READY. Verified shipped in commit `eefbe10` (v2.0.78) — CLAUDE-LITE.md, verify-packs.sh, integration tests, deviation catalog all present. Its `**Status**:` markdown block (not YAML) slipped past the #37 reconcile. Frontmatter-only; now nothing is falsely pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)