### PR TITLE
feat: AgentOS Shared State Kernel & Schema-Validated Capability Contracts

### DIFF
--- a/genesis/2026-07-17-agentos-state-kernel.md
+++ b/genesis/2026-07-17-agentos-state-kernel.md
@@ -1,0 +1,405 @@
+---
+prd_id: agentos-state-kernel
+title: AgentOS — Shared State Kernel & Schema-Validated Capability Contracts
+version: 1.0
+status: READY
+created: 2026-07-17
+author: samibs
+last_updated: 2026-07-17
+
+# DEPENDENCIES (for inter-PRD coordination)
+dependencies:
+  requires: []
+  recommends:
+    - correctness-contracts        # AC gates / test-intent enforcement — shares the "contract" concept
+    - real-autonomous-agents       # agents that consume/produce structured state
+  blocks: []
+  shared_with:
+    - skillfoundry-v3-mcp-agent-server   # MCP handoffs should carry the same schemas
+    - folder-state-and-checkbox-reconciler
+
+tags: [core, architecture, agents, state, contracts, reliability]
+priority: high
+layers: [backend]
+domains: []
+---
+
+# PRD: AgentOS — Shared State Kernel & Schema-Validated Capability Contracts
+
+> **Design principle (single line):** the inter-agent intermediate representation is
+> **terse, human-inspectable, schema-validated JSON** — semantically anchored to the
+> models' training distribution — **not** opaque bitstrings, float arrays, or
+> hidden-state embeddings. Embeddings are provider-fragile and API-blocked; JSON is
+> native to both the developer's eyes and the LLM's reasoning. This PRD builds *only*
+> the positive JSON-IR architecture; the tensor/embedding debate is out of scope.
+
+---
+
+## 1. Overview
+
+### 1.1 Problem Statement
+
+Today SkillFoundry agents (102 markdown prompt files) exchange work as **free-text
+payloads** over the existing `agent-message-bus.ts`, and the pipeline threads state as
+prose and files. Two failure classes result: (a) a downstream agent receives an
+upstream agent's *narrative* rather than a validated data shape, so shapes silently
+drift (the Frontend-Backend Contract failure, generalized to agent-to-agent); and (b)
+when an `/autonomous` or `/swarm` run goes wrong there is **no single authoritative,
+inspectable record of task state** — you cannot answer "what does the run believe is
+true right now?" at 2 AM. Gates (Anvil, Semgrep, Checkov) run as pipeline *phases*
+that produce reports, but nothing prevents an agent from *asserting* success in prose
+that contradicts what the deterministic engine measured.
+
+### 1.2 Proposed Solution
+
+Introduce two coordinated primitives on top of the **existing** message bus and gate
+engine — not a rewrite:
+
+1. **Project State Kernel** — one durable, versioned, JSON-Schema-validated state
+   document per task (`.skillfoundry/runs/<id>/state/state.json`), partitioned into
+   owner-scoped slices (`coder_state`, `tester_state`, `security_state`, …). It stores
+   **references, hashes, and metrics — never large artifact blobs**. It is the single
+   source of truth for the run.
+2. **Capability Contracts** — each agent capability declares an `input_schema` and
+   `output_schema`. Handoffs and gate-guarded state writes go through a
+   **validate → repair → retry** path (because the default provider does *not*
+   guarantee grammar-constrained output). Anvil/gates act as the write barrier: an
+   agent's proposed slice update is committed only if the deterministic validators
+   pass; otherwise the failure is written back into state as structured error data,
+   forcing a retry. Natural language is generated **lazily**, only at human boundaries.
+
+### 1.3 Success Metrics
+
+| Metric | Current | Target | How to Measure |
+|--------|---------|--------|----------------|
+| Agent-handoff shape mismatches per 100 handoffs | unmeasured (prose) | 0 schema-invalid commits | Contract validator reject counter in run log |
+| Malformed-output recovery | ad hoc `output-repair` | ≥99% recovered within 2 retries, else hard-halt | Retry/halt counters per run |
+| "What is the run state?" answer time (audit) | manual log grep | 1 file read (`state.json`) | Presence of authoritative state doc |
+| False success (agent claims pass, gate says fail) | possible | 0 committed | Cross-check: committed slice vs gate verdict |
+| Existing agents broken by rollout | n/a | 0 regressions | Full test suite + parity on unconverted agents |
+
+---
+
+## 2. User Stories
+
+### Primary User: Framework Maintainer / Autonomous-Run Operator
+
+| ID | As a... | I want to... | So that... | Priority | FR-IDs |
+|----|---------|--------------|------------|----------|--------|
+| US-001 | operator | read one `state.json` to see exactly what the run believes | I can debug a rogue 2 AM run without reconstructing prose | MUST | FR-001, FR-002 |
+| US-002 | maintainer | force every agent handoff through a JSON schema | downstream agents never parse an upstream agent's narrative | MUST | FR-003, FR-004 |
+| US-003 | maintainer | have gates block state writes, not just emit reports | an agent cannot "gaslight" the run into a false success | MUST | FR-005, FR-006 |
+| US-004 | operator | see clean success output and only get prose post-mortems on failure | I'm not drowned in agent-to-agent chatter on the happy path | SHOULD | FR-007 |
+| US-005 | maintainer | adopt contracts incrementally without converting all 102 agents at once | rollout carries zero regressions | MUST | FR-008 |
+| US-006 | operator | have concurrent agents write disjoint slices safely | `/swarm` and parallel execution don't lose updates | MUST | FR-009 |
+
+---
+
+## 3. Functional Requirements
+
+### 3.1 Core Features
+
+| ID | Requirement | Description | Acceptance Criteria |
+|----|-------------|-------------|---------------------|
+| FR-001 | State Kernel store | `state.ts` in `sf_cli/src/core/` managing a per-run `state.json` with typed slices | Given a run starts, When the kernel initializes, Then a schema-valid `state.json` with `project_metadata` + empty owner slices exists on disk |
+| FR-002 | References not blobs (spill, don't reject) | State stores file paths, content hashes, and scalar metrics only; oversized string fields spill to disk transparently | Given an agent writes a string field > configurable `maxFieldBytes`, When the slice is committed, Then the kernel writes the value to `state/artifacts/<sha256>` and replaces the field with `{ref, hash, bytes}`; the write is rejected ONLY if the disk spill itself fails |
+| FR-003 | Capability schemas | Each agent capability declares `input_schema`/`output_schema` (JSON Schema) | Given an agent definition, When it is loaded, Then its capability schemas are registered; missing schema on a *converted* agent is a load-time error |
+| FR-004 | Validated handoffs | Handoffs over the existing message bus carry schema-validated payloads | Given agent A hands off to B, When the payload fails B's `input_schema`, Then delivery is rejected and logged, never delivered as-is |
+| FR-005 | Gate-guarded writes | State-slice commits are intercepted by Anvil/gates before merge | Given an agent proposes a `coder_state` update, When gates fail, Then the write is rejected and the failure is written to state as structured `error_logs`, not merged |
+| FR-006 | Validate→repair→retry (per-slice halt) | Non-conforming model output is repaired then retried; halt is scoped to the failing slice, not the whole run | Given a model emits invalid JSON, When repair fails twice, Then the owning slice is marked `FAILED` with structured `error_logs` (no silent pass, no infinite loop, reuses `output-repair.ts`); independent sibling slices continue; the whole run aborts only if a *required* slice failed or the global consecutive-failure threshold trips |
+| FR-007 | Lazy language projection | NL is generated only at human boundaries (final summary, failure post-mortem) | Given a successful autonomous run, When it completes, Then the terminal shows a compact state summary, not agent-to-agent transcripts; on repeated gate failure a Summary skill renders a human post-mortem |
+| FR-008 | Incremental adoption | Contracts apply first to handoffs, then per-agent, behind a capability flag | Given unconverted markdown agents, When a run executes, Then they operate unchanged; only agents declaring schemas are enforced |
+| FR-009 | Write authority + versioning (CAS recovery) | Each slice has a single owning agent + monotonic version; stale writes rebase and retry, never silently drop | Given two agents write concurrently, When both target the same slice, Then the stale-version write is rejected (optimistic concurrency) and the loser re-reads the current slice, rebases its change onto the new version, re-validates, and retries the commit (max 3 attempts) before escalating; cross-slice writes proceed in parallel |
+
+### 3.2 User Interface Requirements
+
+No graphical UI. The operator-facing surface is the CLI and the on-disk state file:
+
+- **Terminal (happy path):** a compact, single-block run summary rendered from the
+  final state document — no agent-to-agent transcript printed (FR-007).
+- **Terminal (failure path):** a human-readable post-mortem generated by a Summary
+  skill from the failing slice's structured `error_logs`.
+- **State file:** `.skillfoundry/runs/<id>/state/state.json`, pretty-printed and
+  directly human-inspectable, is the audit surface (US-001).
+
+### 3.3 API Requirements
+
+No public HTTP API is introduced. All interfaces are in-process TypeScript (state
+kernel + contract validator) layered on the existing message bus. See §6 for why the
+API Contract section is skipped.
+
+---
+
+## 4. Non-Functional Requirements
+
+### 4.1 Performance
+
+| Metric | Requirement |
+|--------|-------------|
+| State read/write | < 5 ms local file op; no network in the write path |
+| Contract validation | < 10 ms per handoff (compiled JSON Schema cached) |
+| Added latency per gated write | Bounded by existing gate runtime; no new model calls except repair retries |
+
+### 4.2 Security
+
+| Aspect | Requirement |
+|--------|-------------|
+| Authentication | N/A — local, single-user CLI process |
+| Authorization | Write authority: a slice is writable only by its declared owner agent (FR-009) |
+| Data Protection | State may reference file paths but MUST NOT embed secrets; run redaction (`redact.ts`) applied before any sync/export |
+| Input Validation | All cross-agent payloads validated at the boundary; `maxFieldBytes`, max array size, max nesting depth enforced (injection-resistance) |
+| Error Handling | Structured error codes into state; **no stack traces** surfaced to users; no silent failure (BPSBS) |
+| Determinism boundary | Only deterministic validators may set `build_status=PASSING`; an agent-authored slice can never self-certify pass |
+
+### 4.3 Reliability
+
+- Repair loop is **bounded** (halt after 2, reusing the
+  `CONSECUTIVE_FAILURE_HALT_THRESHOLD` discipline already in `pipeline.ts`) — no
+  infinite retries.
+- State writes are atomic (write-temp + rename) and versioned; a crashed run leaves a
+  readable last-valid `state.json`.
+
+---
+
+## 5. Technical Specifications
+
+### 5.1 State home & on-disk layout
+
+State lives in a **dedicated `state/` subdir inside the run dir** (resolves OQ-1) —
+per-run isolation, a same-filesystem scratch location for atomic temp+rename, and a
+namespace for spilled artifacts and version snapshots:
+
+```
+.skillfoundry/runs/<id>/
+└── state/
+    ├── state.json            # authoritative document (pretty-printed)
+    ├── state.json.tmp        # atomic write staging (rename → state.json)
+    └── artifacts/
+        └── <sha256>          # spilled oversized fields (FR-002)
+```
+
+#### State document shape (references/metrics only — no blobs)
+
+```json
+{
+  "schema_version": 1,
+  "run_id": "…",
+  "project_metadata": { "target": "node-typescript", "build_status": "PASSING" },
+  "slices": {
+    "coder_state":    { "version": 4, "owner": "coder",    "modified_files": ["src/auth.ts"], "diff_hash": "sha256:…", "complexity_delta": 4 },
+    "tester_state":   { "version": 2, "owner": "tester",   "test_runs": 48, "failures": 0, "coverage": 96 },
+    "security_state": { "version": 1, "owner": "security", "critical_vulns": 0, "warnings": 1 }
+  }
+}
+```
+
+- `coverage`, `severity`, `build_status`, etc. keep their **semantic labels** — never
+  positional/opaque encodings.
+- Large artifacts (full diffs, ASTs, logs) live on disk under the run dir; state stores
+  the **path + hash** only.
+
+### 5.2 Capability contract shape & authoring (resolves OQ-3)
+
+**Authoring model:** each capability's `input_schema`/`output_schema` is **co-located in
+the agent's own front-matter** (the agent owns its contract), while **shared types**
+(`Severity`, `Finding`, `FileRef`, …) live centrally in `schemas/` and are referenced by
+`$ref`. At load time all schemas compile into **one registry** (mirroring the existing
+`agent-registry` / `agent-prompt-loader` pattern), giving a single lookup + dedup surface
+and preventing per-agent copies of common types from drifting.
+
+```yaml
+# agents/security_agent.md front-matter
+capability: analyze
+input_schema:  { type: object, properties: { diff_ref: {type: string}, dependencies: {type: array, items: {type: string}} }, required: [diff_ref] }
+output_schema:
+  type: object
+  required: [vulnerabilities]
+  properties:
+    vulnerabilities: { type: array, items: { $ref: "schemas/finding.json#/Finding" } }
+```
+
+```json
+// schemas/finding.json — shared, $ref'd by many agents (single source of truth)
+{ "Severity": { "type": "string", "enum": ["LOW", "MEDIUM", "HIGH", "CRITICAL"] },
+  "Finding": { "type": "object", "required": ["severity", "file"],
+    "properties": { "severity": {"$ref": "#/Severity"}, "file": {"type": "string"},
+      "line": {"type": "integer"}, "fix_suggestion": {"type": "string"} } } }
+```
+
+### 5.3 Write path (the "MMU" barrier)
+
+```
+agent produces output
+  → validate against output_schema  ──fail──► repair (output-repair.ts) ──fail x2──► HALT (structured error)
+  → gate barrier (gates.ts / micro-gates.ts: static build, semgrep, tests)
+        ──fail──► write structured error_logs to slice, build_status=FAIL, force retry
+        ──pass──► version-guarded commit to owned slice (reject if stale version)
+  → lazy NL projection only if a human boundary is crossed
+```
+
+### 5.4 Corrections applied vs. the original proposal
+
+| # | Original claim | Correction (normative in this PRD) |
+|---|----------------|-------------------------------------|
+| 1 | "Model literally cannot emit malformed prose (constrained decoding)" | Default provider (Anthropic) has **no** grammar-constrained output; contracts use **validate → repair → retry → halt**. Constrained-decode is a provider-specific *optimization*, not a guarantee. |
+| 2 | "Replace agents chatting with a central state" (as if greenfield) | The typed **message bus already exists**; this builds the *durable state kernel + schemas* on top, reusing the bus. |
+| 3 | "Turns the agent into a deterministic compiler pass" | Agents remain **stochastic producers**; only **gates are deterministic**. The guarantee lives at the gate/write barrier, not the model call. |
+| 4 | `ast_changes: "…"` inside shared state | State stores **references + hashes + metrics only**; blobs stay on disk (FR-002). |
+| 5 | "Each agent owns a slice" (no concurrency model) | Add **write authority + per-slice version guard** (optimistic concurrency) for `/swarm`/parallel safety (FR-009). |
+| 6 | Tensor/embedding rebuttal as architecture | Demoted to a one-line design principle; **out of scope** as a requirement. |
+
+### 5.5 Affected modules
+
+| Module | Change |
+|--------|--------|
+| `sf_cli/src/core/state.ts` | **NEW** — kernel: typed slices, versioned atomic writes, refs-only validation |
+| `sf_cli/src/core/agent-message-bus.ts` | Add schema-validation middleware on payloads |
+| `sf_cli/src/core/pipeline.ts` | Route slice commits through the gate barrier; wire kernel into run dir |
+| `sf_cli/src/core/gates.ts` / `micro-gates.ts` | Expose gate barrier as write interceptor; deterministic-only `PASSING` |
+| `sf_cli/src/core/output-repair.ts` | Reused for the repair step of validate→repair→retry |
+| `agents/*.md` | Opt-in: add capability `input_schema`/`output_schema` in front-matter (Coder, Tester, Security first) |
+| `schemas/` | **NEW** — central shared type definitions (`Severity`, `Finding`, `FileRef`) `$ref`'d by agent contracts (OQ-3) |
+| `mcp-server/` | MCP tool schemas **generated** from the canonical registry — a projection, never hand-duplicated (OQ-2) |
+
+---
+
+## 6. Contract Specification (Required for API Features)
+
+**Skip reason:** This PRD introduces **no HTTP/network API and no request/response
+endpoints**. All contracts are in-process TypeScript interfaces (the state kernel) and
+per-agent JSON Schemas, both fully specified in §5. There is no wire contract to freeze
+here. The JSON-Schema capability contracts in §5.2 are the equivalent "frozen shape"
+for agent-to-agent handoffs.
+
+---
+
+## 7. Constraints & Assumptions
+
+### 7.1 Constraints
+
+- Must layer on the **existing** `agent-message-bus.ts` — no replacement of inter-agent
+  transport.
+- Default provider (Anthropic) offers no grammar-constrained decoding; the design
+  cannot assume guaranteed-valid model output.
+- Must not require converting all 102 markdown agents at once (incremental — FR-008).
+- State is **per-run**; no cross-run or global shared state in this PRD.
+
+### 7.2 Assumptions
+
+- `output-repair.ts` can be driven programmatically for the repair step.
+- Run directory `.skillfoundry/runs/<id>/state/` is writable, on a single filesystem
+  (so temp+rename is atomic), and is the state home (OQ-1).
+- OpenAI/Gemini strict JSON-schema modes are available and can be used as a "strict"
+  optimization where the provider supports them.
+
+### 7.3 Out of Scope
+
+- Hidden-state / embedding / tensor passing between agents (rejected: provider-fragile,
+  API-blocked).
+- Converting every markdown agent to schemas (incremental rollout only).
+- Replacing the message bus.
+- A graphical UI (the dashboard may render `state.json` later, separately).
+- Cross-run / global shared state.
+
+---
+
+## 8. Regression Surface
+
+Existing behavior that this change could break — must be verified unchanged:
+
+| Feature at Risk | Why at Risk | Verification |
+|-----------------|-------------|--------------|
+| Existing message-bus handoffs (unconverted agents) | New validation middleware sits in the delivery path | Unconverted agents bypass enforcement; full existing bus tests pass |
+| `/forge` & `/go` pipeline runs | Kernel + gate-barrier wiring touches `pipeline.ts` | End-to-end pipeline run on a sample PRD produces identical artifacts |
+| Anvil / micro-gate reporting | Gates repurposed as write interceptors | Gate reports still emitted; pass/fail verdicts unchanged on known fixtures |
+| `output-repair.ts` current callers | Reused in a new loop | Existing repair unit tests pass; no behavior change for current callers |
+| `/swarm` parallel execution | New per-slice version guard | Concurrent-write test: disjoint slices succeed, stale same-slice write rejected |
+
+---
+
+## 9. Risks & Mitigations
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| Provider without constrained decode emits invalid JSON often | Retry churn, latency | Repair-first path; per-provider "strict mode" when available (OpenAI/Gemini), repair fallback for Anthropic |
+| Schema rigidity blocks legitimate agent output | Stalled runs | Start schemas permissive (required-fields-only), tighten with telemetry; flag-gated rollout |
+| Slice ownership disputes under `/swarm` | Lost updates | Single-owner write authority + version guard; cross-slice parallelism only |
+| Adoption cost across 102 agents | Slow ROI | Handoff-level contracts first (highest leverage), per-agent second |
+| State file grows unbounded | Context bloat | References + hashes only; `maxFieldBytes` cap; artifacts on disk |
+
+---
+
+## 10. Implementation Plan
+
+| Phase | Deliverable | Depends on |
+|-------|-------------|-----------|
+| 1 — Kernel | `state.ts`: typed slices, versioned atomic writes, refs-only validation; wired into `pipeline.ts` run dir | — |
+| 2 — Gate barrier | Slice commits routed through `gates.ts`/`micro-gates.ts`; deterministic-only `PASSING` | Phase 1 |
+| 3 — Handoff contracts | Schema-validate message-bus payloads; validate→repair→retry via `output-repair.ts` | Phase 1 |
+| 4 — Per-agent schemas | Opt-in capability schemas; convert Coder, Tester, Security first | Phase 3 |
+| 5 — Lazy projection | Compact success output + failure-only post-mortem Summary skill | Phases 2–4 |
+
+---
+
+## 11. Acceptance Criteria
+
+### 11.1 Definition of Done
+
+- [ ] `state.ts` kernel implemented with typed slices, atomic versioned writes, refs-only validation (FR-001, FR-002)
+- [ ] Capability schema registration + load-time error for converted agents missing a schema (FR-003)
+- [ ] Message-bus payloads schema-validated at delivery; invalid payloads rejected and logged (FR-004)
+- [ ] Slice commits gated by Anvil/gates; failures written as structured `error_logs`, never merged (FR-005)
+- [ ] Validate→repair→retry loop bounded, halting after 2 with a structured error (FR-006)
+- [ ] Lazy NL projection: compact success summary, failure-only post-mortem (FR-007)
+- [ ] Unconverted markdown agents run unchanged behind the capability flag (FR-008)
+- [ ] Per-slice version guard: concurrent disjoint writes succeed, stale same-slice writes rejected (FR-009)
+- [ ] All items in §8 Regression Surface verified with tests
+- [ ] Unit + integration tests ≥ 80% on new `state.ts` and contract-validation code
+- [ ] Public interfaces documented (kernel API, contract schema format)
+- [ ] No new CRITICAL GuardLoop patterns detected (`/guardloop scan` clean)
+
+### 11.2 Acceptance Scenarios (Gherkin)
+
+```
+Scenario: Agent cannot self-certify a passing build
+  Given the coder agent proposes a coder_state update claiming success
+  And the deterministic gate barrier reports a failing build
+  When the commit is attempted
+  Then the write is rejected
+  And build_status remains FAIL with structured error_logs in state
+
+Scenario: Concurrent slice writes are race-safe
+  Given the tester and security agents write their own slices concurrently
+  When both commits are applied
+  Then both succeed
+  But a second write to tester_state carrying a stale version is rejected
+  And the rejected writer re-reads tester_state, rebases its change onto the
+    current version, re-validates, and retries the commit (max 3) before escalating
+
+Scenario: Malformed model output is bounded, not silently accepted
+  Given an agent emits JSON that fails its output_schema
+  When repair fails twice
+  Then the run halts with a structured error and no slice is committed
+```
+
+---
+
+## 12. Appendix
+
+### 12.1 Resolved Design Decisions
+
+Formerly open questions — resolved to best practice and made normative above:
+
+| ID | Question | Decision | Rationale | Where |
+|----|----------|----------|-----------|-------|
+| OQ-1 | State home: run dir or dedicated subdir? | **Dedicated `state/` subdir inside the run dir** | Per-run isolation, same-filesystem scratch for atomic temp+rename, namespaces spilled artifacts/snapshots | §5.1, §7.2 |
+| OQ-2 | MCP server: same schemas or a projection? | **Single source of truth — MCP tool schemas are a *generated projection* of the canonical registry** | Hand-duplicated wire schemas would drift — the exact contract-mismatch failure this PRD exists to eliminate | §5.5 |
+| OQ-3 | Schema authoring: co-located or central registry? | **Hybrid — capability schema co-located in agent front-matter; shared types centralized in `schemas/` and `$ref`'d; all compiled into one registry at load** | Agent owns its contract (locality) while common types (`Severity`, `Finding`) have one definition; mirrors the existing agent-registry pattern | §5.2, §5.5 |
+
+### 12.2 Resolved Gaps (from PRD-lint semantic pass)
+
+| Gap | Decision | Rationale | Where |
+|-----|----------|-----------|-------|
+| Oversized `maxFieldBytes` field | **Transparent spill to `state/artifacts/<hash>`; replace field with `{ref,hash,bytes}`. Reject only if the disk write fails.** | Hard-rejecting a legitimate large diff would stall the run; spilling *is* the "refs not blobs" principle | FR-002, §5.1 |
+| Halt scope on repair exhaustion | **Per-slice `FAILED` marking; independent siblings continue; whole-run abort only if a required slice fails or the global consecutive-failure threshold trips** | Bounds `/swarm` blast radius; consistent with existing halt-on-repeated-blocker discipline (no false success) | FR-006, §11.2 |
+| Stale-version write recovery | **Bounded compare-and-swap: re-read → rebase → re-validate → retry (max 3) → escalate. Never silently drop the update.** | Standard optimistic-concurrency recovery; a dropped update is a silent lost write | FR-009, §11.2 |

--- a/sf_cli/package-lock.json
+++ b/sf_cli/package-lock.json
@@ -12,6 +12,7 @@
         "@anthropic-ai/sdk": "^0.39.0",
         "@iarna/toml": "^2.2.5",
         "@xenova/transformers": "^2.17.2",
+        "ajv": "^8.20.0",
         "better-sqlite3": "^11.7.0",
         "chalk": "^5.4.1",
         "commander": "^13.1.0",
@@ -1133,6 +1134,22 @@
         "node": ">= 8.0.0"
       }
     },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
     "node_modules/ansi-escapes": {
       "version": "7.3.0",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.3.0.tgz",
@@ -2048,10 +2065,32 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
     "node_modules/fast-fifo": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
       "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ=="
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
+      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fdir": {
       "version": "6.5.0",
@@ -2459,6 +2498,12 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
     },
     "node_modules/long": {
       "version": "4.0.0",
@@ -3031,6 +3076,15 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }

--- a/sf_cli/package.json
+++ b/sf_cli/package.json
@@ -21,6 +21,7 @@
     "@anthropic-ai/sdk": "^0.39.0",
     "@iarna/toml": "^2.2.5",
     "@xenova/transformers": "^2.17.2",
+    "ajv": "^8.20.0",
     "better-sqlite3": "^11.7.0",
     "chalk": "^5.4.1",
     "commander": "^13.1.0",

--- a/sf_cli/src/core/__tests__/message-contracts.test.ts
+++ b/sf_cli/src/core/__tests__/message-contracts.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect, vi } from 'vitest';
+import { AgentMessageBus } from '../agent-message-bus.js';
+import {
+  MessageContractRegistry,
+  createContractMiddleware,
+} from '../message-contracts.js';
+
+// A representative result:complete contract: payload must carry a numeric coverage.
+const COVERAGE_SCHEMA = {
+  type: 'object',
+  required: ['coverage'],
+  properties: { coverage: { type: 'number' } },
+  additionalProperties: true,
+};
+
+describe('MessageContractRegistry.validate', () => {
+  it('passes a payload that matches the registered schema', () => {
+    const reg = new MessageContractRegistry();
+    reg.register('result:complete', COVERAGE_SCHEMA);
+    const msg = AgentMessageBus.buildMessage('tester', 'gate', 'result:complete', {
+      coverage: 96,
+    });
+    const r = reg.validate(msg);
+    expect(r.valid).toBe(true);
+    expect(r.enforced).toBe(true);
+    expect(r.errors).toEqual([]);
+  });
+
+  it('fails a payload that violates the schema and reports readable errors', () => {
+    const reg = new MessageContractRegistry();
+    reg.register('result:complete', COVERAGE_SCHEMA);
+    const msg = AgentMessageBus.buildMessage('tester', 'gate', 'result:complete', {
+      coverage: 'ninety-six',
+    });
+    const r = reg.validate(msg);
+    expect(r.valid).toBe(false);
+    expect(r.enforced).toBe(true);
+    expect(r.errors.join(' ')).toMatch(/coverage|number/i);
+  });
+
+  it('treats an unregistered (type, recipient) as valid-but-unenforced (FR-008)', () => {
+    const reg = new MessageContractRegistry();
+    const msg = AgentMessageBus.buildMessage('a', 'b', 'status:heartbeat', {
+      anything: true,
+    });
+    const r = reg.validate(msg);
+    expect(r.valid).toBe(true);
+    expect(r.enforced).toBe(false);
+  });
+
+  it('prefers a recipient-specific contract over the wildcard one', () => {
+    const reg = new MessageContractRegistry();
+    // Wildcard: lax. Specific to "strict-agent": requires a "token".
+    reg.register('task:delegate', { type: 'object' });
+    reg.register(
+      'task:delegate',
+      { type: 'object', required: ['token'], properties: { token: { type: 'string' } } },
+      'strict-agent',
+    );
+    const toStrict = AgentMessageBus.buildMessage('x', 'strict-agent', 'task:delegate', {});
+    const toOther = AgentMessageBus.buildMessage('x', 'other', 'task:delegate', {});
+    expect(reg.validate(toStrict).valid).toBe(false); // missing token
+    expect(reg.validate(toOther).valid).toBe(true); // wildcard is lax
+  });
+
+  it('surfaces a malformed schema at registration time', () => {
+    const reg = new MessageContractRegistry();
+    expect(() =>
+      reg.register('result:complete', { type: 'not-a-real-type' }),
+    ).toThrow();
+  });
+
+  it('has() reports contract presence including wildcard fallback', () => {
+    const reg = new MessageContractRegistry();
+    reg.register('memory:store', { type: 'object' });
+    expect(reg.has('memory:store', 'anyone')).toBe(true);
+    expect(reg.has('memory:query', 'anyone')).toBe(false);
+  });
+});
+
+describe('createContractMiddleware — bus integration (FR-004)', () => {
+  it('drops an invalid message so subscribers never receive it', () => {
+    const bus = new AgentMessageBus();
+    const reg = new MessageContractRegistry();
+    reg.register('result:complete', COVERAGE_SCHEMA);
+    const onReject = vi.fn();
+    bus.use(createContractMiddleware(reg, { onReject }));
+
+    const received: unknown[] = [];
+    bus.subscribe('result:complete', (m) => received.push(m.payload));
+
+    bus.publish(
+      AgentMessageBus.buildMessage('tester', 'gate', 'result:complete', {
+        coverage: 'bad',
+      }),
+    );
+
+    expect(received).toHaveLength(0); // never delivered
+    expect(onReject).toHaveBeenCalledOnce();
+  });
+
+  it('delivers a valid message unchanged', () => {
+    const bus = new AgentMessageBus();
+    const reg = new MessageContractRegistry();
+    reg.register('result:complete', COVERAGE_SCHEMA);
+    bus.use(createContractMiddleware(reg));
+
+    const received: unknown[] = [];
+    bus.subscribe('result:complete', (m) => received.push(m.payload));
+
+    bus.publish(
+      AgentMessageBus.buildMessage('tester', 'gate', 'result:complete', { coverage: 96 }),
+    );
+
+    expect(received).toEqual([{ coverage: 96 }]);
+  });
+
+  it('lets unenforced message types through (incremental adoption)', () => {
+    const bus = new AgentMessageBus();
+    const reg = new MessageContractRegistry(); // nothing registered
+    bus.use(createContractMiddleware(reg));
+
+    const received: unknown[] = [];
+    bus.subscribe('status:heartbeat', (m) => received.push(m.payload));
+
+    bus.publish(
+      AgentMessageBus.buildMessage('a', 'b', 'status:heartbeat', { beat: 1 }),
+    );
+
+    expect(received).toEqual([{ beat: 1 }]);
+  });
+});

--- a/sf_cli/src/core/__tests__/message-schemas.test.ts
+++ b/sf_cli/src/core/__tests__/message-schemas.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi } from 'vitest';
+import { AgentMessageBus } from '../agent-message-bus.js';
+import { MessageContractRegistry } from '../message-contracts.js';
+import {
+  FINDING_SCHEMA,
+  SEVERITY_SCHEMA,
+  DEFAULT_MESSAGE_CONTRACTS,
+  buildDefaultRegistry,
+  installMessageContracts,
+} from '../message-schemas.js';
+
+describe('shared type schemas (single source of truth)', () => {
+  it('FINDING_SCHEMA validates a real finding and rejects a bad severity', () => {
+    const reg = new MessageContractRegistry();
+    reg.register('result:complete', FINDING_SCHEMA);
+    const good = AgentMessageBus.buildMessage('sec', 'gate', 'result:complete', {
+      severity: 'HIGH',
+      file: 'src/auth.ts',
+      line: 42,
+    });
+    const bad = AgentMessageBus.buildMessage('sec', 'gate', 'result:complete', {
+      severity: 'SPICY',
+      file: 'src/auth.ts',
+    });
+    expect(reg.validate(good).valid).toBe(true);
+    expect(reg.validate(bad).valid).toBe(false);
+  });
+
+  it('SEVERITY_SCHEMA enumerates the four canonical levels', () => {
+    expect(SEVERITY_SCHEMA.enum).toEqual(['LOW', 'MEDIUM', 'HIGH', 'CRITICAL']);
+  });
+});
+
+describe('default registry (permissive baseline)', () => {
+  it('covers every one of the 8 message types', () => {
+    expect(DEFAULT_MESSAGE_CONTRACTS).toHaveLength(8);
+    const reg = buildDefaultRegistry();
+    for (const c of DEFAULT_MESSAGE_CONTRACTS) {
+      expect(reg.has(c.type, 'anyone')).toBe(true);
+    }
+  });
+
+  it('accepts the real agent-pool heartbeat payload (no false rejection)', () => {
+    const reg = buildDefaultRegistry();
+    const heartbeat = AgentMessageBus.buildMessage('agent-pool', '*', 'status:heartbeat', {
+      running: 2,
+      queued: 5,
+      completed: 10,
+      failed: 0,
+      maxConcurrency: 4,
+    });
+    expect(reg.validate(heartbeat).valid).toBe(true);
+  });
+
+  it('rejects a non-object (narrative) payload for a covered type', () => {
+    const reg = buildDefaultRegistry();
+    const narrative = AgentMessageBus.buildMessage(
+      'coder',
+      'tester',
+      'task:delegate',
+      // A stray string handoff — the failure mode contracts exist to stop.
+      'please write some tests for the thing' as unknown as Record<string, unknown>,
+    );
+    expect(reg.validate(narrative).valid).toBe(false);
+  });
+
+  it('supports extra strict per-recipient contracts alongside the baseline', () => {
+    const reg = buildDefaultRegistry([
+      { type: 'result:complete', schema: FINDING_SCHEMA, recipient: 'gate' },
+    ]);
+    const toGate = AgentMessageBus.buildMessage('sec', 'gate', 'result:complete', {
+      severity: 'LOW',
+      file: 'x.ts',
+    });
+    const missingFields = AgentMessageBus.buildMessage('sec', 'gate', 'result:complete', {
+      note: 'looks fine',
+    });
+    expect(reg.validate(toGate).valid).toBe(true);
+    expect(reg.validate(missingFields).valid).toBe(false); // strict for recipient 'gate'
+    // A different recipient falls back to the permissive baseline.
+    const toOther = AgentMessageBus.buildMessage('sec', 'other', 'result:complete', {
+      note: 'looks fine',
+    });
+    expect(reg.validate(toOther).valid).toBe(true);
+  });
+});
+
+describe('installMessageContracts (opt-in)', () => {
+  it('installs enforcing middleware on a bus and drops invalid messages', () => {
+    const bus = new AgentMessageBus();
+    const onReject = vi.fn();
+    installMessageContracts(bus, buildDefaultRegistry(), { onReject });
+
+    const received: unknown[] = [];
+    bus.subscribe('task:delegate', (m) => received.push(m.payload));
+
+    // valid object payload → delivered
+    bus.publish(
+      AgentMessageBus.buildMessage('a', 'b', 'task:delegate', { story: 'STORY-1' }),
+    );
+    // invalid string payload → dropped
+    bus.publish(
+      AgentMessageBus.buildMessage(
+        'a',
+        'b',
+        'task:delegate',
+        'do it' as unknown as Record<string, unknown>,
+      ),
+    );
+
+    expect(received).toEqual([{ story: 'STORY-1' }]);
+    expect(onReject).toHaveBeenCalledOnce();
+  });
+});

--- a/sf_cli/src/core/__tests__/state-gate-barrier.test.ts
+++ b/sf_cli/src/core/__tests__/state-gate-barrier.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdirSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { StateKernel } from '../state.js';
+import {
+  GateBarrier,
+  fromGateSummary,
+  type SliceProposal,
+  type GateVerdict,
+} from '../state-gate-barrier.js';
+import type { GateRunSummary } from '../gates.js';
+
+const runDir = join(process.cwd(), '.tmp-test-gate-barrier');
+
+beforeEach(() => {
+  rmSync(runDir, { recursive: true, force: true });
+  mkdirSync(runDir, { recursive: true });
+});
+
+afterEach(() => {
+  rmSync(runDir, { recursive: true, force: true });
+});
+
+const pass: GateVerdict = { verdict: 'PASS', errors: [] };
+const fail: GateVerdict = {
+  verdict: 'FAIL',
+  errors: [{ tier: 'T2', name: 'canary', detail: 'module failed to compile' }],
+};
+
+function proposal(over: Partial<SliceProposal> = {}): SliceProposal {
+  return { slice: 'coder_state', owner: 'coder', data: { files: ['a.ts'] }, ...over };
+}
+
+describe('GateBarrier.commit — gates PASS (FR-005)', () => {
+  it('commits the proposed data to the kernel when gates pass', async () => {
+    const k = StateKernel.create(runDir, 'r');
+    const barrier = new GateBarrier(k, () => pass);
+
+    const res = await barrier.commit(proposal(), 0);
+
+    expect(res.committed).toBe(true);
+    expect(res.verdict).toBe('PASS');
+    expect(res.slice.version).toBe(1);
+    expect(k.getSlice('coder_state')?.files).toEqual(['a.ts']);
+    // A passing agent write does NOT mark the run PASSING (run-level decision).
+    expect(k.getBuildStatus()).toBe('UNKNOWN');
+  });
+});
+
+describe('GateBarrier.commit — gates FAIL (FR-005 / §4.2)', () => {
+  it('rejects the proposal, marks the slice FAILED, and flips build_status to FAILING', async () => {
+    const k = StateKernel.create(runDir, 'r');
+    const barrier = new GateBarrier(k, () => fail);
+
+    const res = await barrier.commit(proposal(), 0);
+
+    expect(res.committed).toBe(false);
+    expect(res.verdict).toBe('FAIL');
+    // Proposed payload was NOT merged...
+    expect(k.getSlice('coder_state')?.files).toBeUndefined();
+    // ...instead the slice carries structured error_logs.
+    expect(k.getSlice('coder_state')?.status).toBe('FAILED');
+    expect(k.getSlice('coder_state')?.error_logs).toEqual(fail.errors);
+    expect(k.getBuildStatus()).toBe('FAILING');
+  });
+
+  it('an agent cannot self-certify: a failing gate wins over the proposed data', async () => {
+    const k = StateKernel.create(runDir, 'r');
+    // Agent tries to claim success in its own payload; gate says otherwise.
+    const barrier = new GateBarrier(k, () => fail);
+    const res = await barrier.commit(
+      proposal({ data: { build_status: 'PASSING', files: [] } }),
+      0,
+    );
+    expect(res.committed).toBe(false);
+    expect(k.getBuildStatus()).toBe('FAILING');
+  });
+});
+
+describe('GateBarrier — per-slice halt keeps siblings alive (FR-006)', () => {
+  it('blocking coder_state leaves an already-committed tester_state untouched', async () => {
+    const k = StateKernel.create(runDir, 'r');
+    // A sibling slice commits fine through a passing barrier.
+    const okBarrier = new GateBarrier(k, () => pass);
+    await okBarrier.commit(
+      { slice: 'tester_state', owner: 'tester', data: { coverage: 96 } },
+      0,
+    );
+    // The coder slice is blocked.
+    const badBarrier = new GateBarrier(k, () => fail);
+    await badBarrier.commit(proposal(), 0);
+
+    expect(k.getSlice('tester_state')?.coverage).toBe(96);
+    expect(k.getSlice('tester_state')?.status).toBeUndefined();
+    expect(k.getSlice('coder_state')?.status).toBe('FAILED');
+  });
+});
+
+describe('GateBarrier — WARN handling', () => {
+  it('treats WARN as a soft pass by default (commits)', async () => {
+    const k = StateKernel.create(runDir, 'r');
+    const barrier = new GateBarrier(k, () => ({ verdict: 'WARN', errors: [] }));
+    const res = await barrier.commit(proposal(), 0);
+    expect(res.committed).toBe(true);
+    expect(res.verdict).toBe('WARN');
+  });
+
+  it('blocks WARN when strictWarn is enabled', async () => {
+    const k = StateKernel.create(runDir, 'r');
+    const barrier = new GateBarrier(k, () => ({ verdict: 'WARN', errors: [] }), {
+      strictWarn: true,
+    });
+    const res = await barrier.commit(proposal(), 0);
+    expect(res.committed).toBe(false);
+    expect(k.getSlice('coder_state')?.status).toBe('FAILED');
+  });
+});
+
+describe('GateBarrier — async validators & call fidelity', () => {
+  it('awaits an async validator and passes the proposal to it', async () => {
+    const k = StateKernel.create(runDir, 'r');
+    const validator = vi.fn(async (_p: SliceProposal) => pass);
+    const barrier = new GateBarrier(k, validator);
+    const p = proposal();
+    await barrier.commit(p, 0);
+    expect(validator).toHaveBeenCalledOnce();
+    expect(validator).toHaveBeenCalledWith(p);
+  });
+});
+
+describe('fromGateSummary — adapter', () => {
+  it('maps a FAIL summary to a verdict with only failing tiers as error logs', () => {
+    const summary: GateRunSummary = {
+      gates: [
+        { tier: 'T1', name: 'syntax', status: 'pass', detail: 'ok', durationMs: 1 },
+        { tier: 'T2', name: 'canary', status: 'fail', detail: 'ENOENT', durationMs: 2 },
+        { tier: 'T3', name: 'adversarial', status: 'warn', detail: 'risky', durationMs: 3 },
+      ],
+      passed: 1,
+      failed: 1,
+      warned: 1,
+      skipped: 0,
+      totalMs: 6,
+      verdict: 'FAIL',
+    };
+    const v = fromGateSummary(summary);
+    expect(v.verdict).toBe('FAIL');
+    expect(v.errors).toEqual([{ tier: 'T2', name: 'canary', detail: 'ENOENT' }]);
+  });
+
+  it('maps a clean PASS summary to an empty error list', () => {
+    const summary: GateRunSummary = {
+      gates: [{ tier: 'T1', name: 'syntax', status: 'pass', detail: 'ok', durationMs: 1 }],
+      passed: 1,
+      failed: 0,
+      warned: 0,
+      skipped: 0,
+      totalMs: 1,
+      verdict: 'PASS',
+    };
+    expect(fromGateSummary(summary)).toEqual({ verdict: 'PASS', errors: [] });
+  });
+});

--- a/sf_cli/src/core/__tests__/state-projection.test.ts
+++ b/sf_cli/src/core/__tests__/state-projection.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdirSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { StateKernel } from '../state.js';
+import { projectState, projectKernel } from '../state-projection.js';
+import type { StateDocument } from '../state.js';
+
+const runDir = join(process.cwd(), '.tmp-test-state-projection');
+
+beforeEach(() => {
+  rmSync(runDir, { recursive: true, force: true });
+  mkdirSync(runDir, { recursive: true });
+});
+afterEach(() => {
+  rmSync(runDir, { recursive: true, force: true });
+});
+
+function doc(over: Partial<StateDocument> = {}): StateDocument {
+  return {
+    schema_version: 1,
+    run_id: 'forge-123',
+    project_metadata: { build_status: 'PASSING', target: 'node-typescript' },
+    slices: {},
+    ...over,
+  };
+}
+
+describe('projectState — success (FR-007 happy path)', () => {
+  it('renders a compact one-block summary with per-slice metrics', () => {
+    const d = doc({
+      slices: {
+        tester_state: { version: 1, owner: 'tester', coverage: 96, failures: 0 },
+        coder_state: { version: 2, owner: 'coder', modified_files: ['a.ts', 'b.ts'] },
+      },
+    });
+    const p = projectState(d);
+    expect(p.mode).toBe('success');
+    expect(p.text).toContain('✓ forge-123 (node-typescript) — build PASSING');
+    expect(p.text).toContain('tester_state: coverage=96, failures=0');
+    expect(p.text).toContain('coder_state: modified_files=[2]');
+    // No control fields leak into the summary.
+    expect(p.text).not.toContain('version=');
+    expect(p.text).not.toContain('owner=');
+    // No agent chatter, just derived metrics.
+    expect(p.text.split('\n')).toHaveLength(3);
+  });
+
+  it('marks a spilled field compactly rather than dumping the blob', () => {
+    const d = doc({
+      slices: {
+        coder_state: {
+          version: 1,
+          owner: 'coder',
+          diff: { __spilled: true, ref: 'state/artifacts/abc', hash: 'sha256:abc', bytes: 4096 },
+        },
+      },
+    });
+    const p = projectState(d);
+    expect(p.text).toContain('diff=<spilled 4096B>');
+  });
+});
+
+describe('projectState — failure (FR-007 post-mortem)', () => {
+  it('renders a post-mortem from a FAILED slice error_logs', () => {
+    const d = doc({
+      project_metadata: { build_status: 'FAILING' },
+      slices: {
+        coder_state: {
+          version: 1,
+          owner: 'coder',
+          status: 'FAILED',
+          error_logs: [
+            { tier: 'T2', name: 'canary', detail: 'module failed to compile' },
+            { tier: 'T1', name: 'syntax', detail: 'banned pattern: TODO' },
+          ],
+        },
+        tester_state: { version: 1, owner: 'tester', coverage: 88 },
+      },
+    });
+    const p = projectState(d);
+    expect(p.mode).toBe('failure');
+    expect(p.text).toContain('✗ forge-123 — build FAILING');
+    expect(p.text).toContain('coder_state FAILED (owner: coder)');
+    expect(p.text).toContain('- [T2] canary: module failed to compile');
+    expect(p.text).toContain('- [T1] syntax: banned pattern: TODO');
+    // The passing sibling is not part of the post-mortem.
+    expect(p.text).not.toContain('tester_state');
+  });
+
+  it('treats build_status FAILING with no failed slice as a failure with a note', () => {
+    const d = doc({ project_metadata: { build_status: 'FAILING' }, slices: {} });
+    const p = projectState(d);
+    expect(p.mode).toBe('failure');
+    expect(p.text).toContain('no slice recorded a failure');
+  });
+});
+
+describe('projectKernel — reads from disk', () => {
+  it('projects a real kernel after a barrier-style FAILED write', () => {
+    const k = StateKernel.create(runDir, 'forge-xyz');
+    k.commitSlice(
+      'coder_state',
+      'coder',
+      { status: 'FAILED', error_logs: [{ tier: 'T2', name: 'canary', detail: 'boom' }] },
+      0,
+    );
+    k.setBuildStatus('FAILING');
+    const p = projectKernel(k);
+    expect(p.mode).toBe('failure');
+    expect(p.text).toContain('coder_state FAILED');
+    expect(p.text).toContain('boom');
+  });
+});

--- a/sf_cli/src/core/__tests__/state.test.ts
+++ b/sf_cli/src/core/__tests__/state.test.ts
@@ -1,0 +1,226 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { existsSync, readFileSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import {
+  StateKernel,
+  StaleVersionError,
+  WriteAuthorityError,
+  SpillError,
+  isSpilledRef,
+  STATE_SCHEMA_VERSION,
+  type SpilledRef,
+  type StateDocument,
+} from '../state.js';
+
+const runDir = join(process.cwd(), '.tmp-test-state-kernel');
+
+beforeEach(() => {
+  rmSync(runDir, { recursive: true, force: true });
+  mkdirSync(runDir, { recursive: true });
+});
+
+afterEach(() => {
+  rmSync(runDir, { recursive: true, force: true });
+});
+
+function readDoc(): StateDocument {
+  return JSON.parse(
+    readFileSync(join(runDir, 'state', 'state.json'), 'utf-8'),
+  ) as StateDocument;
+}
+
+describe('StateKernel.create (FR-001)', () => {
+  it('initializes a schema-valid state.json with empty slices in a dedicated state/ dir', () => {
+    const k = StateKernel.create(runDir, 'run-123', { target: 'node-typescript' });
+
+    expect(existsSync(join(runDir, 'state', 'state.json'))).toBe(true);
+    expect(existsSync(join(runDir, 'state', 'artifacts'))).toBe(true);
+
+    const doc = readDoc();
+    expect(doc.schema_version).toBe(STATE_SCHEMA_VERSION);
+    expect(doc.run_id).toBe('run-123');
+    expect(doc.project_metadata.build_status).toBe('UNKNOWN');
+    expect(doc.project_metadata.target).toBe('node-typescript');
+    expect(doc.slices).toEqual({});
+    expect(k.path).toContain(join('state', 'state.json'));
+  });
+
+  it('refuses to clobber an existing state document', () => {
+    StateKernel.create(runDir, 'run-1');
+    expect(() => StateKernel.create(runDir, 'run-1')).toThrow(/already exists/);
+  });
+
+  it('open() reattaches to an existing run and exists() reports presence', () => {
+    expect(StateKernel.exists(runDir)).toBe(false);
+    StateKernel.create(runDir, 'run-1');
+    expect(StateKernel.exists(runDir)).toBe(true);
+    const reopened = StateKernel.open(runDir);
+    expect(reopened.load().run_id).toBe('run-1');
+  });
+
+  it('open() throws when no state exists', () => {
+    expect(() => StateKernel.open(runDir)).toThrow(/No state document/);
+  });
+});
+
+describe('StateKernel.commitSlice — versioning & write authority (FR-009)', () => {
+  it('creates a slice from expectedVersion 0 and stamps owner + version 1', () => {
+    const k = StateKernel.create(runDir, 'r');
+    const slice = k.commitSlice('tester_state', 'tester', { coverage: 96 }, 0);
+    expect(slice.version).toBe(1);
+    expect(slice.owner).toBe('tester');
+    expect(slice.coverage).toBe(96);
+    expect(k.getSlice('tester_state')?.version).toBe(1);
+  });
+
+  it('increments version on each successful commit', () => {
+    const k = StateKernel.create(runDir, 'r');
+    k.commitSlice('coder_state', 'coder', { files: ['a.ts'] }, 0);
+    const v2 = k.commitSlice('coder_state', 'coder', { files: ['a.ts', 'b.ts'] }, 1);
+    expect(v2.version).toBe(2);
+  });
+
+  it('rejects a stale-version write with StaleVersionError', () => {
+    const k = StateKernel.create(runDir, 'r');
+    k.commitSlice('tester_state', 'tester', { runs: 1 }, 0); // now version 1
+    expect(() => k.commitSlice('tester_state', 'tester', { runs: 2 }, 0)).toThrow(
+      StaleVersionError,
+    );
+  });
+
+  it('rejects a write from an agent that does not own the slice', () => {
+    const k = StateKernel.create(runDir, 'r');
+    k.commitSlice('tester_state', 'tester', { runs: 1 }, 0);
+    expect(() =>
+      k.commitSlice('tester_state', 'security', { runs: 2 }, 1),
+    ).toThrow(WriteAuthorityError);
+  });
+
+  it('allows concurrent writes to DISJOINT slices (cross-slice independence)', () => {
+    const k = StateKernel.create(runDir, 'r');
+    const t = k.commitSlice('tester_state', 'tester', { failures: 0 }, 0);
+    const s = k.commitSlice('security_state', 'security', { critical_vulns: 0 }, 0);
+    expect(t.version).toBe(1);
+    expect(s.version).toBe(1);
+    const doc = readDoc();
+    expect(Object.keys(doc.slices).sort()).toEqual([
+      'security_state',
+      'tester_state',
+    ]);
+  });
+});
+
+describe('StateKernel.updateSlice — CAS rebase recovery (FR-009)', () => {
+  it('re-reads, rebases and commits after a concurrent write moved the version', () => {
+    const k = StateKernel.create(runDir, 'r');
+    k.commitSlice('coder_state', 'coder', { count: 1 }, 0); // version 1
+
+    let firstPass = true;
+    const result = k.updateSlice('coder_state', 'coder', (current) => {
+      // Simulate a concurrent writer bumping the slice on the first attempt only,
+      // forcing a StaleVersionError and a rebase onto the newer version.
+      if (firstPass) {
+        firstPass = false;
+        k.commitSlice('coder_state', 'coder', { count: 99 }, 1); // now version 2
+      }
+      const count = (current.count as number) ?? 0;
+      return { count: count + 1 };
+    });
+
+    // The mutator's final rebase saw count=99 → committed 100 at version 3.
+    expect(result.count).toBe(100);
+    expect(result.version).toBe(3);
+  });
+
+  it('throws after exhausting maxAttempts under sustained contention', () => {
+    const k = StateKernel.create(runDir, 'r');
+    k.commitSlice('coder_state', 'coder', { count: 0 }, 0);
+    expect(() =>
+      k.updateSlice(
+        'coder_state',
+        'coder',
+        (current) => {
+          // Always bump the version out from under the commit.
+          const v = k.getSlice('coder_state')!.version;
+          k.commitSlice('coder_state', 'coder', { count: (current.count as number) ?? 0 }, v);
+          return { count: 1 };
+        },
+        2,
+      ),
+    ).toThrow(/exhausted 2 attempts/);
+  });
+});
+
+describe('StateKernel — refs not blobs / spill (FR-002)', () => {
+  it('spills an oversized string field to state/artifacts and replaces it with a pointer', () => {
+    const k = StateKernel.create(runDir, 'r', {}, { maxFieldBytes: 16 });
+    const big = 'x'.repeat(1000);
+    const slice = k.commitSlice('coder_state', 'coder', { diff: big, note: 'small' }, 0);
+
+    expect(isSpilledRef(slice.diff)).toBe(true);
+    const ref = slice.diff as SpilledRef;
+    expect(ref.bytes).toBe(1000);
+    expect(ref.hash).toMatch(/^sha256:[a-f0-9]{64}$/);
+    expect(ref.ref).toContain(join('state', 'artifacts'));
+    // Small field passes through untouched.
+    expect(slice.note).toBe('small');
+    // Artifact content is recoverable and matches.
+    expect(k.readArtifact(ref)).toBe(big);
+    // The stored state.json contains only the pointer, not the blob.
+    expect(JSON.stringify(readDoc())).not.toContain(big);
+  });
+
+  it('leaves within-limit and non-string fields unchanged', () => {
+    const k = StateKernel.create(runDir, 'r', {}, { maxFieldBytes: 8192 });
+    const slice = k.commitSlice(
+      'tester_state',
+      'tester',
+      { coverage: 96, name: 'short', passed: true },
+      0,
+    );
+    expect(slice.coverage).toBe(96);
+    expect(slice.name).toBe('short');
+    expect(slice.passed).toBe(true);
+  });
+
+  it('rejects the write with SpillError only when the disk spill fails', () => {
+    const k = StateKernel.create(runDir, 'r', {}, { maxFieldBytes: 4 });
+    // Remove the artifacts dir AND block its recreation by placing a file where the
+    // directory should be, so writeFileSync into it fails.
+    rmSync(join(runDir, 'state', 'artifacts'), { recursive: true, force: true });
+    // Recreate as a *file*, not a dir → writes under it throw ENOTDIR.
+    mkdirSync(join(runDir, 'state'), { recursive: true });
+    writeFileSync(join(runDir, 'state', 'artifacts'), 'blocker');
+    expect(() =>
+      k.commitSlice('coder_state', 'coder', { diff: 'toolong' }, 0),
+    ).toThrow(SpillError);
+  });
+});
+
+describe('StateKernel — determinism boundary (§4.2)', () => {
+  it('build_status starts UNKNOWN and only setBuildStatus can change it', () => {
+    const k = StateKernel.create(runDir, 'r');
+    expect(k.getBuildStatus()).toBe('UNKNOWN');
+    // An agent slice cannot carry build_status into project_metadata.
+    k.commitSlice('coder_state', 'coder', { build_status: 'PASSING' }, 0);
+    expect(k.getBuildStatus()).toBe('UNKNOWN'); // unchanged by agent data
+    k.setBuildStatus('PASSING');
+    expect(k.getBuildStatus()).toBe('PASSING');
+  });
+});
+
+describe('StateKernel — atomic persistence & crash safety (§4.3)', () => {
+  it('never leaves a lingering temp file after a commit', () => {
+    const k = StateKernel.create(runDir, 'r');
+    k.commitSlice('coder_state', 'coder', { files: ['a.ts'] }, 0);
+    expect(existsSync(join(runDir, 'state', 'state.json.tmp'))).toBe(false);
+    expect(existsSync(join(runDir, 'state', 'state.json'))).toBe(true);
+  });
+
+  it('persists across a fresh kernel instance (disk is the source of truth)', () => {
+    const k1 = StateKernel.create(runDir, 'r');
+    k1.commitSlice('tester_state', 'tester', { coverage: 88 }, 0);
+    const k2 = StateKernel.open(runDir);
+    expect(k2.getSlice('tester_state')?.coverage).toBe(88);
+  });
+});

--- a/sf_cli/src/core/message-contracts.ts
+++ b/sf_cli/src/core/message-contracts.ts
@@ -1,0 +1,137 @@
+// Message Contracts — schema-validated agent handoffs on the existing message bus
+// (AgentOS PRD FR-004 / FR-008: genesis/2026-07-17-agentos-state-kernel.md).
+//
+// Downstream agents must never parse an upstream agent's narrative. This registry
+// holds a JSON Schema per (message type, recipient) and exposes a bus middleware that
+// validates each message's payload BEFORE delivery. An invalid payload is dropped
+// (the middleware does not call next()) and logged — never delivered as-is.
+//
+// Adoption is incremental (FR-008): a message whose (type, recipient) has no
+// registered schema passes through unenforced. Only declared contracts are enforced,
+// so unconverted agents keep working while contracts are added one handoff at a time.
+
+import { Ajv, type ValidateFunction, type ErrorObject } from 'ajv';
+import type { AgentMessage, MessageType } from '../types.js';
+import type { MiddlewareFn } from './agent-message-bus.js';
+import { getLogger } from '../utils/logger.js';
+
+const logger = getLogger();
+
+/** Recipient wildcard: a schema registered under '*' applies to any recipient. */
+const ANY_RECIPIENT = '*';
+
+/** Result of validating one message against its registered contract. */
+export interface ValidationResult {
+  /** True if valid OR if no contract is registered for this (type, recipient). */
+  valid: boolean;
+  /** True only when a contract existed and was applied. */
+  enforced: boolean;
+  /** Human-readable validation errors (empty when valid). */
+  errors: string[];
+}
+
+export interface ContractMiddlewareOptions {
+  /** Invoked when a message is rejected, for custom handling (metrics, dead-letter). */
+  onReject?: (message: AgentMessage, errors: string[]) => void;
+}
+
+/**
+ * Compiles and stores JSON Schemas for agent-to-agent message payloads, keyed by
+ * message type and recipient. A recipient-specific contract takes precedence over a
+ * wildcard one.
+ */
+export class MessageContractRegistry {
+  private readonly ajv = new Ajv({ allErrors: true, strict: false });
+  private readonly validators = new Map<string, ValidateFunction>();
+
+  private static key(type: MessageType, recipient: string): string {
+    return `${type}::${recipient}`;
+  }
+
+  /**
+   * Register a payload schema for a message `type`, optionally scoped to a specific
+   * `recipient` (defaults to all recipients). Throws if the schema fails to compile,
+   * surfacing malformed contracts at registration time rather than at delivery.
+   *
+   * @param type - The MessageType this contract applies to.
+   * @param schema - JSON Schema validated against `message.payload`.
+   * @param recipient - Recipient agent id, or '*' for any (default).
+   */
+  register(
+    type: MessageType,
+    schema: Record<string, unknown>,
+    recipient: string = ANY_RECIPIENT,
+  ): void {
+    const validate = this.ajv.compile(schema);
+    this.validators.set(MessageContractRegistry.key(type, recipient), validate);
+  }
+
+  /** Whether any contract (specific or wildcard) is registered for this message. */
+  has(type: MessageType, recipient: string): boolean {
+    return this.resolve(type, recipient) !== undefined;
+  }
+
+  /** Resolve the most specific validator: exact recipient first, then wildcard. */
+  private resolve(
+    type: MessageType,
+    recipient: string,
+  ): ValidateFunction | undefined {
+    return (
+      this.validators.get(MessageContractRegistry.key(type, recipient)) ??
+      this.validators.get(MessageContractRegistry.key(type, ANY_RECIPIENT))
+    );
+  }
+
+  /**
+   * Validate a message's payload against its registered contract. When no contract is
+   * registered the message is considered valid but not enforced (FR-008).
+   */
+  validate(message: AgentMessage): ValidationResult {
+    const validate = this.resolve(message.type, message.recipient);
+    if (!validate) {
+      return { valid: true, enforced: false, errors: [] };
+    }
+    const valid = validate(message.payload) as boolean;
+    if (valid) {
+      return { valid: true, enforced: true, errors: [] };
+    }
+    return {
+      valid: false,
+      enforced: true,
+      errors: formatErrors(validate.errors),
+    };
+  }
+}
+
+/** Turn Ajv's error objects into concise, human-readable strings. */
+function formatErrors(errors: ErrorObject[] | null | undefined): string[] {
+  if (!errors || errors.length === 0) return ['payload failed schema validation'];
+  return errors.map((e) => `payload${e.instancePath || ''} ${e.message ?? 'is invalid'}`.trim());
+}
+
+/**
+ * Build a bus middleware that enforces registered message contracts. Install with
+ * `bus.use(createContractMiddleware(registry))`. Invalid messages are dropped (not
+ * delivered) and logged; valid or unenforced messages proceed via `next()`.
+ */
+export function createContractMiddleware(
+  registry: MessageContractRegistry,
+  options: ContractMiddlewareOptions = {},
+): MiddlewareFn {
+  return (message, next) => {
+    const result = registry.validate(message);
+    if (result.valid) {
+      next();
+      return;
+    }
+    logger.warn('message-bus', 'contract_rejected', {
+      type: message.type,
+      sender: message.sender,
+      recipient: message.recipient,
+      correlationId: message.correlationId,
+      errors: result.errors,
+    });
+    options.onReject?.(message, result.errors);
+    // Do NOT call next() — the invalid message is dropped, never delivered as-is.
+  };
+}

--- a/sf_cli/src/core/message-schemas.ts
+++ b/sf_cli/src/core/message-schemas.ts
@@ -1,0 +1,111 @@
+// Message Schemas — shared JSON-Schema types and the default contract registry for
+// agent handoffs (AgentOS PRD STORY-004; OQ-3 authoring decision).
+//
+// Shared types (Severity, Finding, FileRef) live here as the single source of truth so
+// many agents reference one definition rather than drifting copies. The default
+// contracts are intentionally PERMISSIVE (required-fields-only, additionalProperties
+// allowed): per the PRD risk table we "start permissive and tighten with telemetry",
+// so installing them cannot reject a legitimate in-flight message.
+//
+// This module does NOT auto-install on the global bus — that is an opt-in, flag-gated
+// rollout decision (`installMessageContracts`). Wiring it into the live runtime with
+// tightened per-recipient contracts is the follow-on to this story.
+
+import type { MessageType } from '../types.js';
+import {
+  MessageContractRegistry,
+  createContractMiddleware,
+  type ContractMiddlewareOptions,
+} from './message-contracts.js';
+import type { AgentMessageBus } from './agent-message-bus.js';
+
+// ── Shared reusable type schemas (single source of truth) ──────────────────
+
+/** Severity levels used across security/quality findings. */
+export const SEVERITY_SCHEMA = {
+  type: 'string',
+  enum: ['LOW', 'MEDIUM', 'HIGH', 'CRITICAL'],
+} as const;
+
+/** A reference to a file + optional content hash (refs-not-blobs, FR-002). */
+export const FILE_REF_SCHEMA = {
+  type: 'object',
+  required: ['file'],
+  properties: {
+    file: { type: 'string' },
+    hash: { type: 'string' },
+  },
+  additionalProperties: true,
+} as const;
+
+/** A single finding emitted by an analysis agent. Strict — reused by opt-in contracts. */
+export const FINDING_SCHEMA = {
+  type: 'object',
+  required: ['severity', 'file'],
+  properties: {
+    severity: SEVERITY_SCHEMA,
+    file: { type: 'string' },
+    line: { type: 'integer' },
+    fix_suggestion: { type: 'string' },
+  },
+  additionalProperties: true,
+} as const;
+
+// ── Default per-MessageType contracts (permissive; safe to install) ────────
+
+/** A contract entry: a schema for a MessageType, optionally scoped to a recipient. */
+export interface ContractEntry {
+  type: MessageType;
+  schema: Record<string, unknown>;
+  recipient?: string;
+}
+
+const OBJECT_PAYLOAD = { type: 'object', additionalProperties: true } as const;
+
+/**
+ * Permissive baseline contracts for every MessageType. Each only asserts the payload
+ * is an object — enough to reject a stray string/narrative handoff, without rejecting
+ * any structured payload the current system sends.
+ */
+export const DEFAULT_MESSAGE_CONTRACTS: ContractEntry[] = [
+  { type: 'task:delegate', schema: { ...OBJECT_PAYLOAD } },
+  { type: 'task:cancel', schema: { ...OBJECT_PAYLOAD } },
+  { type: 'result:complete', schema: { ...OBJECT_PAYLOAD } },
+  { type: 'result:error', schema: { ...OBJECT_PAYLOAD } },
+  { type: 'status:heartbeat', schema: { ...OBJECT_PAYLOAD } },
+  { type: 'status:request', schema: { ...OBJECT_PAYLOAD } },
+  { type: 'memory:store', schema: { ...OBJECT_PAYLOAD } },
+  { type: 'memory:query', schema: { ...OBJECT_PAYLOAD } },
+];
+
+/**
+ * Build a registry pre-loaded with the default permissive contracts. Callers may
+ * register stricter per-recipient contracts (e.g. using {@link FINDING_SCHEMA}) on the
+ * returned registry before installing it.
+ */
+export function buildDefaultRegistry(
+  extra: ContractEntry[] = [],
+): MessageContractRegistry {
+  const registry = new MessageContractRegistry();
+  for (const c of [...DEFAULT_MESSAGE_CONTRACTS, ...extra]) {
+    registry.register(c.type, c.schema, c.recipient);
+  }
+  return registry;
+}
+
+/**
+ * Install contract enforcement on a bus (opt-in). Returns the registry so callers can
+ * inspect or extend it. Defaults to the permissive baseline.
+ *
+ * @param bus - The message bus to guard.
+ * @param registry - A registry to use (defaults to the baseline registry).
+ * @param options - Reject-handling options forwarded to the middleware.
+ */
+export function installMessageContracts(
+  bus: AgentMessageBus,
+  registry: MessageContractRegistry = buildDefaultRegistry(),
+  options: ContractMiddlewareOptions = {},
+): MessageContractRegistry {
+  bus.use(createContractMiddleware(registry, options));
+  return registry;
+}

--- a/sf_cli/src/core/pipeline.ts
+++ b/sf_cli/src/core/pipeline.ts
@@ -16,6 +16,8 @@ import type { GateRunSummary } from './gates.js';
 import { scorePrd, PrdNotDetectedError, PrdScoringError } from './prd-scorer.js';
 import { AnthropicAdapter } from './provider.js';
 import { ALL_TOOLS } from './tools.js';
+import { StateKernel } from './state.js';
+import { GateBarrier, fromGateSummary } from './state-gate-barrier.js';
 import { getLogger } from '../utils/logger.js';
 import type {
   PipelineOptions,
@@ -1330,6 +1332,46 @@ export async function runPipeline(options: PipelineOptions): Promise<PipelineRes
   // Persist run to disk
   const runsDir = join(workDir, RUNS_DIR);
   if (!existsSync(runsDir)) mkdirSync(runsDir, { recursive: true });
+
+  // ── AgentOS State Kernel: record the run's deterministic outcome ──
+  // Advisory (like the codemap pre-flight): a failure here logs a warning and never
+  // breaks the run. Writes an inspectable <runId>/state/state.json whose build_status
+  // is gate-controlled — the barrier marks the slice FAILED on a failing gate and only
+  // a clean gate PASS with zero failed stories flips the run to PASSING (§4.2).
+  if (gateSummary) {
+    try {
+      const runStateDir = join(runsDir, runId);
+      mkdirSync(runStateDir, { recursive: true });
+      const kernel = StateKernel.create(runStateDir, runId);
+      const barrier = new GateBarrier(kernel, () => fromGateSummary(gateSummary!));
+      const outcome = await barrier.commit(
+        {
+          slice: 'forge_state',
+          owner: 'forge',
+          data: {
+            stories_total: allStoryFiles.length,
+            stories_completed: storiesCompleted,
+            stories_failed: storiesFailed,
+            gates_passed: gateSummary.passed,
+            gates_failed: gateSummary.failed,
+            gates_warned: gateSummary.warned,
+          },
+        },
+        0,
+      );
+      if (gateSummary.verdict === 'PASS' && storiesFailed === 0) {
+        kernel.setBuildStatus('PASSING');
+      }
+      log.info('pipeline', 'state_kernel_recorded', {
+        runId,
+        path: kernel.path,
+        committed: outcome.committed,
+        buildStatus: kernel.getBuildStatus(),
+      });
+    } catch (err) {
+      log.warn('pipeline', 'state_kernel_failed', { runId, error: String(err) });
+    }
+  }
 
   const runBundle = {
     run_id: runId,

--- a/sf_cli/src/core/state-gate-barrier.ts
+++ b/sf_cli/src/core/state-gate-barrier.ts
@@ -1,0 +1,140 @@
+// State Gate Barrier — the "MMU" write barrier from the AgentOS PRD
+// (genesis/2026-07-17-agentos-state-kernel.md, FR-005 / FR-006 / §4.2).
+//
+// An agent never writes the state kernel directly for a gated slice. It proposes an
+// update; the barrier runs the deterministic gate validators; only if they pass does
+// the proposed data reach the kernel. On failure the barrier does NOT merge the
+// proposal — it marks the owning slice FAILED with structured error_logs and flips the
+// run build_status to FAILING, forcing a retry. Because only the one owning slice is
+// touched, sibling slices continue unaffected (FR-006 per-slice halt).
+//
+// The barrier is decoupled from any specific gate runner: it takes a `SliceValidator`.
+// The real pipeline passes the shell-based Anvil/gates through `fromGateSummary`, but
+// tests (and future validators) can supply any function returning a GateVerdict.
+
+import type { GateRunSummary } from './gates.js';
+import { StateKernel, type StateSlice } from './state.js';
+import { getLogger } from '../utils/logger.js';
+
+const logger = getLogger();
+
+/** A single deterministic failure recorded against a slice when a gate blocks a write. */
+export interface GateErrorLog {
+  tier: string;
+  name: string;
+  detail: string;
+}
+
+/** Verdict returned by a {@link SliceValidator}. WARN is a soft pass by default. */
+export interface GateVerdict {
+  verdict: 'PASS' | 'WARN' | 'FAIL';
+  errors: GateErrorLog[];
+}
+
+/** An agent's proposed write to a gated slice, evaluated before it can be committed. */
+export interface SliceProposal {
+  slice: string;
+  owner: string;
+  data: Record<string, unknown>;
+}
+
+/**
+ * Runs the deterministic checks for a proposal and returns a verdict. Sync or async.
+ * The real pipeline wraps its Anvil/gates runner; unit tests inject a stub.
+ */
+export type SliceValidator = (
+  proposal: SliceProposal,
+) => Promise<GateVerdict> | GateVerdict;
+
+/** Outcome of a barrier-guarded commit attempt. */
+export interface BarrierResult {
+  /** True only when gates passed and the proposal was committed to the kernel. */
+  committed: boolean;
+  /** The committed slice (on pass) or the FAILED-marked slice (on block). */
+  slice: StateSlice;
+  verdict: 'PASS' | 'WARN' | 'FAIL';
+  errors: GateErrorLog[];
+}
+
+export interface GateBarrierOptions {
+  /** Treat a WARN verdict as a block instead of a soft pass. Default false. */
+  strictWarn?: boolean;
+}
+
+/**
+ * Adapt a {@link GateRunSummary} (from the shell-based Anvil/gates runner) into a
+ * {@link GateVerdict}, collecting failing tiers as structured error logs.
+ */
+export function fromGateSummary(summary: GateRunSummary): GateVerdict {
+  const errors: GateErrorLog[] = summary.gates
+    .filter((g) => g.status === 'fail')
+    .map((g) => ({ tier: g.tier, name: g.name, detail: g.detail }));
+  return { verdict: summary.verdict, errors };
+}
+
+/**
+ * Guards state writes with a deterministic gate pass (the determinism boundary, §4.2).
+ *
+ * Wrap a {@link StateKernel} and a {@link SliceValidator}; call {@link GateBarrier.commit}
+ * instead of `kernel.commitSlice` for any gated slice.
+ */
+export class GateBarrier {
+  private readonly strictWarn: boolean;
+
+  constructor(
+    private readonly kernel: StateKernel,
+    private readonly validate: SliceValidator,
+    options: GateBarrierOptions = {},
+  ) {
+    this.strictWarn = options.strictWarn ?? false;
+  }
+
+  /**
+   * Attempt to commit `proposal` at `expectedVersion`, guarded by the gate validators.
+   *
+   * - Gates PASS (or WARN when not strict): the proposed data is committed to the
+   *   kernel and returned with `committed: true`.
+   * - Gates FAIL (or WARN when strict): the proposal is rejected — NOT merged. The
+   *   owning slice is marked `{ status: 'FAILED', error_logs }`, run build_status is
+   *   set to FAILING, and `committed: false` is returned so the caller can retry.
+   *
+   * An agent-authored slice therefore can never self-certify a passing build.
+   */
+  async commit(
+    proposal: SliceProposal,
+    expectedVersion: number,
+  ): Promise<BarrierResult> {
+    const { verdict, errors } = await this.validate(proposal);
+    const blocked = verdict === 'FAIL' || (verdict === 'WARN' && this.strictWarn);
+
+    if (blocked) {
+      logger.warn('gate', 'state_write_blocked', {
+        slice: proposal.slice,
+        verdict,
+        failures: errors.length,
+      });
+      // Reject the proposal (do not merge). Record the failure on the owning slice.
+      const failedSlice = this.kernel.commitSlice(
+        proposal.slice,
+        proposal.owner,
+        { status: 'FAILED', error_logs: errors },
+        expectedVersion,
+      );
+      this.kernel.setBuildStatus('FAILING');
+      return { committed: false, slice: failedSlice, verdict, errors };
+    }
+
+    const slice = this.kernel.commitSlice(
+      proposal.slice,
+      proposal.owner,
+      proposal.data,
+      expectedVersion,
+    );
+    logger.info('gate', 'state_write_committed', {
+      slice: proposal.slice,
+      version: slice.version,
+      verdict,
+    });
+    return { committed: true, slice, verdict, errors };
+  }
+}

--- a/sf_cli/src/core/state-projection.ts
+++ b/sf_cli/src/core/state-projection.ts
@@ -1,0 +1,103 @@
+// State Projection — lazy natural-language rendering of run state (AgentOS PRD FR-007).
+//
+// Natural language is a projection layer generated only when a human boundary is
+// crossed, not the medium agents work in. On the happy path this renders a compact
+// one-block success summary from the state document; on failure it renders a
+// human-readable post-mortem from the FAILED slices' structured error_logs. Neither
+// path prints agent-to-agent chatter — the state document is the source, prose is derived.
+
+import { StateKernel, isSpilledRef, type StateDocument, type StateSlice } from './state.js';
+
+/** Control fields present on every slice that are not agent-authored metrics. */
+const SLICE_CONTROL_FIELDS = new Set(['version', 'owner', 'status', 'error_logs']);
+
+export interface Projection {
+  /** 'success' when the run is not failing; 'failure' otherwise. */
+  mode: 'success' | 'failure';
+  /** Human-readable text for the CLI / IDE boundary. */
+  text: string;
+}
+
+/**
+ * Render a state document to a compact success summary or a failure post-mortem.
+ *
+ * A run is considered failing when `build_status` is `FAILING` or any slice is marked
+ * `FAILED` (per-slice halt, FR-006). Otherwise the happy-path summary is produced.
+ */
+export function projectState(doc: StateDocument): Projection {
+  const failedSlices = Object.entries(doc.slices).filter(
+    ([, slice]) => slice.status === 'FAILED',
+  );
+  const failing =
+    doc.project_metadata.build_status === 'FAILING' || failedSlices.length > 0;
+
+  return failing
+    ? { mode: 'failure', text: renderPostMortem(doc, failedSlices) }
+    : { mode: 'success', text: renderSuccess(doc) };
+}
+
+/** Convenience: load a kernel's document and project it. */
+export function projectKernel(kernel: StateKernel): Projection {
+  return projectState(kernel.load());
+}
+
+// ── renderers ──────────────────────────────────────────────────────────────
+
+function renderSuccess(doc: StateDocument): string {
+  const lines: string[] = [];
+  const target = doc.project_metadata.target ? ` (${doc.project_metadata.target})` : '';
+  lines.push(`✓ ${doc.run_id}${target} — build ${doc.project_metadata.build_status}`);
+  for (const [name, slice] of Object.entries(doc.slices)) {
+    const metrics = summariseMetrics(slice);
+    lines.push(`  ${name}: ${metrics || '(no metrics)'}`);
+  }
+  return lines.join('\n');
+}
+
+function renderPostMortem(
+  doc: StateDocument,
+  failedSlices: Array<[string, StateSlice]>,
+): string {
+  const lines: string[] = [];
+  lines.push(`✗ ${doc.run_id} — build ${doc.project_metadata.build_status}`);
+  if (failedSlices.length === 0) {
+    lines.push('  build_status is FAILING but no slice recorded a failure.');
+    return lines.join('\n');
+  }
+  for (const [name, slice] of failedSlices) {
+    lines.push(`  ${name} FAILED (owner: ${slice.owner}):`);
+    const errors = Array.isArray(slice.error_logs) ? slice.error_logs : [];
+    if (errors.length === 0) {
+      lines.push('    - no structured error_logs recorded');
+      continue;
+    }
+    for (const err of errors) {
+      const e = err as { tier?: string; name?: string; detail?: string };
+      const tier = e.tier ? `[${e.tier}] ` : '';
+      const nm = e.name ? `${e.name}: ` : '';
+      lines.push(`    - ${tier}${nm}${e.detail ?? 'failure'}`);
+    }
+  }
+  return lines.join('\n');
+}
+
+/** Compact "k=v" of a slice's agent-authored metric fields (control fields elided). */
+function summariseMetrics(slice: StateSlice): string {
+  const parts: string[] = [];
+  for (const [key, value] of Object.entries(slice)) {
+    if (SLICE_CONTROL_FIELDS.has(key)) continue;
+    if (isSpilledRef(value)) {
+      parts.push(`${key}=<spilled ${value.bytes}B>`);
+    } else if (
+      typeof value === 'number' ||
+      typeof value === 'string' ||
+      typeof value === 'boolean'
+    ) {
+      parts.push(`${key}=${value}`);
+    } else if (Array.isArray(value)) {
+      parts.push(`${key}=[${value.length}]`);
+    }
+    // Objects (non-spilled) are omitted from the compact summary.
+  }
+  return parts.join(', ');
+}

--- a/sf_cli/src/core/state.ts
+++ b/sf_cli/src/core/state.ts
@@ -1,0 +1,375 @@
+// Project State Kernel — the durable, versioned, single source of truth for a run.
+//
+// One state document per run lives at `<runDir>/state/state.json`. It is partitioned
+// into owner-scoped slices (coder_state, tester_state, …). The kernel enforces three
+// invariants from the AgentOS PRD (genesis/2026-07-17-agentos-state-kernel.md):
+//
+//   FR-002  References not blobs — oversized string fields spill to disk transparently
+//           (`state/artifacts/<sha256>`) and are replaced with a {ref,hash,bytes} pointer.
+//           A write is rejected only if the spill itself fails.
+//   FR-009  Write authority + versioning — each slice has a single owning agent and a
+//           monotonic version. A stale-version commit is rejected (optimistic
+//           concurrency); `updateSlice` rebases and retries. Cross-slice writes are
+//           independent.
+//   §4.2    Determinism boundary — only `setBuildStatus` (called by the gate barrier)
+//           may mark the run PASSING. An agent-authored slice can never self-certify.
+//
+// The document on disk is authoritative: every read/write goes through it, and writes
+// are atomic (temp + rename on the same filesystem) so a crash leaves the last valid
+// state.json intact.
+
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+  renameSync,
+} from 'node:fs';
+import { join } from 'node:path';
+import { createHash } from 'node:crypto';
+import { getLogger } from '../utils/logger.js';
+
+const logger = getLogger();
+
+/** Current on-disk schema version. Bump when the document shape changes. */
+export const STATE_SCHEMA_VERSION = 1;
+
+/** Default threshold above which a string field spills to disk (8 KiB). */
+export const DEFAULT_MAX_FIELD_BYTES = 8 * 1024;
+
+/**
+ * Build status for the whole run. Only the deterministic gate barrier may set
+ * `PASSING` via {@link StateKernel.setBuildStatus} — see §4.2 determinism boundary.
+ */
+export type BuildStatus = 'PASSING' | 'FAILING' | 'UNKNOWN';
+
+/**
+ * Pointer left in a slice when a large string field was spilled to disk (FR-002).
+ * `ref` is a run-dir-relative path; `hash` is the content SHA-256; `bytes` is the
+ * original UTF-8 byte length.
+ */
+export interface SpilledRef {
+  __spilled: true;
+  ref: string;
+  hash: string;
+  bytes: number;
+}
+
+/** Type guard for a spilled-field pointer. */
+export function isSpilledRef(value: unknown): value is SpilledRef {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    (value as { __spilled?: unknown }).__spilled === true
+  );
+}
+
+/** An owner-scoped partition of run state. Extra keys are agent-defined data. */
+export interface StateSlice {
+  /** Monotonic version, incremented on every committed write. */
+  version: number;
+  /** The single agent id permitted to write this slice (write authority). */
+  owner: string;
+  [key: string]: unknown;
+}
+
+/** Run-wide metadata. `build_status` is gate-controlled. */
+export interface ProjectMetadata {
+  target?: string;
+  build_status: BuildStatus;
+  [key: string]: unknown;
+}
+
+/** The full state document persisted at `<runDir>/state/state.json`. */
+export interface StateDocument {
+  schema_version: number;
+  run_id: string;
+  project_metadata: ProjectMetadata;
+  slices: Record<string, StateSlice>;
+}
+
+/** Thrown when a slice commit carries a version that no longer matches disk (FR-009). */
+export class StaleVersionError extends Error {
+  constructor(
+    readonly slice: string,
+    readonly expected: number,
+    readonly actual: number,
+  ) {
+    super(
+      `Stale write to slice "${slice}": expected version ${expected}, current is ${actual}. Re-read and rebase.`,
+    );
+    this.name = 'StaleVersionError';
+  }
+}
+
+/** Thrown when an agent writes a slice it does not own (write authority, FR-009). */
+export class WriteAuthorityError extends Error {
+  constructor(
+    readonly slice: string,
+    readonly owner: string,
+    readonly attemptedBy: string,
+  ) {
+    super(
+      `Agent "${attemptedBy}" may not write slice "${slice}" owned by "${owner}".`,
+    );
+    this.name = 'WriteAuthorityError';
+  }
+}
+
+/** Thrown when an oversized field cannot be spilled to disk (the only reject path, FR-002). */
+export class SpillError extends Error {
+  constructor(field: string, cause: unknown) {
+    super(`Failed to spill oversized field "${field}" to disk: ${String(cause)}`);
+    this.name = 'SpillError';
+  }
+}
+
+export interface StateKernelOptions {
+  /** Fields whose UTF-8 length exceeds this spill to disk. Defaults to 8 KiB. */
+  maxFieldBytes?: number;
+}
+
+/**
+ * Manages one run's authoritative state document on disk.
+ *
+ * Construct via {@link StateKernel.create} (fresh run) or {@link StateKernel.open}
+ * (existing run). Every method reads and writes the on-disk document so the file is
+ * always the source of truth — there is no in-memory copy that can diverge.
+ */
+export class StateKernel {
+  private readonly stateDir: string;
+  private readonly statePath: string;
+  private readonly tmpPath: string;
+  private readonly artifactsDir: string;
+  private readonly maxFieldBytes: number;
+
+  private constructor(
+    private readonly runDir: string,
+    options: StateKernelOptions = {},
+  ) {
+    this.stateDir = join(runDir, 'state');
+    this.statePath = join(this.stateDir, 'state.json');
+    this.tmpPath = join(this.stateDir, 'state.json.tmp');
+    this.artifactsDir = join(this.stateDir, 'artifacts');
+    this.maxFieldBytes = options.maxFieldBytes ?? DEFAULT_MAX_FIELD_BYTES;
+  }
+
+  /**
+   * Initialize a fresh state document for `runId` under `runDir` and return its kernel.
+   * Creates `state/` and `state/artifacts/`. Throws if state already exists — use
+   * {@link StateKernel.open} to reattach to an existing run.
+   *
+   * @param runDir - The run directory (e.g. `.skillfoundry/runs/<id>`).
+   * @param runId - Unique run identifier stored in the document.
+   * @param metadata - Optional initial project metadata (build_status defaults to UNKNOWN).
+   */
+  static create(
+    runDir: string,
+    runId: string,
+    metadata: Partial<ProjectMetadata> = {},
+    options: StateKernelOptions = {},
+  ): StateKernel {
+    const kernel = new StateKernel(runDir, options);
+    if (existsSync(kernel.statePath)) {
+      throw new Error(
+        `State already exists at ${kernel.statePath}. Use StateKernel.open() instead.`,
+      );
+    }
+    mkdirSync(kernel.artifactsDir, { recursive: true });
+    const doc: StateDocument = {
+      schema_version: STATE_SCHEMA_VERSION,
+      run_id: runId,
+      project_metadata: { build_status: 'UNKNOWN', ...metadata },
+      slices: {},
+    };
+    kernel.persist(doc);
+    logger.info('persist', 'state_kernel_init', { runId, path: kernel.statePath });
+    return kernel;
+  }
+
+  /**
+   * Reattach to an existing run's state document (crash recovery / resume).
+   * Throws if no state document is present.
+   */
+  static open(runDir: string, options: StateKernelOptions = {}): StateKernel {
+    const kernel = new StateKernel(runDir, options);
+    if (!existsSync(kernel.statePath)) {
+      throw new Error(`No state document found at ${kernel.statePath}.`);
+    }
+    // Ensure the artifacts dir exists even for older runs.
+    mkdirSync(kernel.artifactsDir, { recursive: true });
+    return kernel;
+  }
+
+  /** Whether a state document exists for this run directory. */
+  static exists(runDir: string): boolean {
+    return existsSync(join(runDir, 'state', 'state.json'));
+  }
+
+  /** Read and parse the authoritative state document from disk. */
+  load(): StateDocument {
+    const raw = readFileSync(this.statePath, 'utf-8');
+    return JSON.parse(raw) as StateDocument;
+  }
+
+  /** Return a copy of a single slice, or `undefined` if it does not exist yet. */
+  getSlice(name: string): StateSlice | undefined {
+    const slice = this.load().slices[name];
+    return slice ? { ...slice } : undefined;
+  }
+
+  /** Current run build status. */
+  getBuildStatus(): BuildStatus {
+    return this.load().project_metadata.build_status;
+  }
+
+  /**
+   * Commit `data` to `name` as `owner`, guarded by optimistic concurrency (FR-009).
+   *
+   * - The slice is writable only by its `owner` (throws {@link WriteAuthorityError}).
+   * - `expectedVersion` must equal the slice's current version (0 for a new slice),
+   *   else {@link StaleVersionError} is thrown so the caller can rebase and retry.
+   * - Oversized string fields in `data` spill to disk before the commit (FR-002).
+   *
+   * @returns The newly committed slice, including its incremented `version`.
+   */
+  commitSlice(
+    name: string,
+    owner: string,
+    data: Record<string, unknown>,
+    expectedVersion: number,
+  ): StateSlice {
+    const doc = this.load();
+    const existing = doc.slices[name];
+    const currentVersion = existing ? existing.version : 0;
+
+    if (existing && existing.owner !== owner) {
+      throw new WriteAuthorityError(name, existing.owner, owner);
+    }
+    if (expectedVersion !== currentVersion) {
+      throw new StaleVersionError(name, expectedVersion, currentVersion);
+    }
+
+    const spilled = this.spillOversized(data);
+    const nextSlice: StateSlice = {
+      ...spilled,
+      owner,
+      version: currentVersion + 1,
+    };
+    doc.slices[name] = nextSlice;
+    this.persist(doc);
+    return { ...nextSlice };
+  }
+
+  /**
+   * Read-modify-write a slice with automatic rebase on contention (FR-009 recovery).
+   *
+   * Re-reads the current slice, applies `mutator` to produce the new data, and commits.
+   * On {@link StaleVersionError} it re-reads and retries up to `maxAttempts` (default 3)
+   * before rethrowing — a losing writer never silently drops its update.
+   *
+   * @param name - Slice name.
+   * @param owner - Writing agent id (must own the slice if it exists).
+   * @param mutator - Given the current slice data (`{}` if new), returns the next data.
+   * @param maxAttempts - Max CAS attempts before escalating (default 3).
+   */
+  updateSlice(
+    name: string,
+    owner: string,
+    mutator: (current: Record<string, unknown>) => Record<string, unknown>,
+    maxAttempts = 3,
+  ): StateSlice {
+    let lastError: unknown;
+    for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+      const existing = this.getSlice(name);
+      const currentVersion = existing?.version ?? 0;
+      // Strip control fields before handing data to the mutator.
+      const currentData: Record<string, unknown> = { ...existing };
+      delete currentData.version;
+      delete currentData.owner;
+      const nextData = mutator(currentData);
+      try {
+        return this.commitSlice(name, owner, nextData, currentVersion);
+      } catch (err) {
+        if (err instanceof StaleVersionError) {
+          lastError = err;
+          logger.warn('persist', 'state_cas_retry', {
+            slice: name,
+            attempt,
+            maxAttempts,
+          });
+          continue;
+        }
+        throw err;
+      }
+    }
+    throw new Error(
+      `updateSlice exhausted ${maxAttempts} attempts on slice "${name}" due to contention: ${String(lastError)}`,
+    );
+  }
+
+  /**
+   * Set the run build status. This is the ONLY way `PASSING` reaches the document and
+   * is reserved for the deterministic gate barrier (§4.2 determinism boundary). Agents
+   * write metrics into their own slices; they cannot self-certify the build.
+   */
+  setBuildStatus(status: BuildStatus): void {
+    const doc = this.load();
+    doc.project_metadata.build_status = status;
+    this.persist(doc);
+  }
+
+  /** Read a spilled artifact's raw content back given its {@link SpilledRef}. */
+  readArtifact(ref: SpilledRef): string {
+    return readFileSync(join(this.runDir, ref.ref), 'utf-8');
+  }
+
+  /** Absolute path to this run's state.json (for logging / inspection). */
+  get path(): string {
+    return this.statePath;
+  }
+
+  // ── internals ────────────────────────────────────────────────────────────
+
+  /**
+   * Replace any top-level string field longer than `maxFieldBytes` with a spilled
+   * pointer, writing the content to `state/artifacts/<sha256>`. Non-string and
+   * within-limit fields pass through unchanged. Throws {@link SpillError} if the
+   * disk write fails — the only path that rejects a commit (FR-002).
+   */
+  private spillOversized(
+    data: Record<string, unknown>,
+  ): Record<string, unknown> {
+    const out: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(data)) {
+      if (typeof value === 'string' && Buffer.byteLength(value, 'utf8') > this.maxFieldBytes) {
+        const hash = createHash('sha256').update(value, 'utf8').digest('hex');
+        const artifactPath = join(this.artifactsDir, hash);
+        try {
+          if (!existsSync(artifactPath)) {
+            writeFileSync(artifactPath, value, 'utf-8');
+          }
+        } catch (err) {
+          throw new SpillError(key, err);
+        }
+        const ref: SpilledRef = {
+          __spilled: true,
+          ref: join('state', 'artifacts', hash),
+          hash: `sha256:${hash}`,
+          bytes: Buffer.byteLength(value, 'utf8'),
+        };
+        out[key] = ref;
+      } else {
+        out[key] = value;
+      }
+    }
+    return out;
+  }
+
+  /** Atomically write the document: stage to a temp file, then rename into place. */
+  private persist(doc: StateDocument): void {
+    const json = JSON.stringify(doc, null, 2);
+    writeFileSync(this.tmpPath, json, 'utf-8');
+    renameSync(this.tmpPath, this.statePath);
+  }
+}


### PR DESCRIPTION
Implements PRD `genesis/2026-07-17-agentos-state-kernel.md` (all 5 stories). Adds a durable, versioned, inspectable run-state kernel and schema-validated agent handoffs on top of the **existing** message bus and gate engine — no rewrite.

## Stories

| Story | What | Files |
|-------|------|-------|
| STORY-001 | **State Kernel** — versioned owner-scoped slices, atomic temp+rename, refs-not-blobs spill, CAS rebase, gate-only build status | `state.ts` |
| STORY-002 | **Gate barrier** — proposals commit only past deterministic gates; failures mark slice `FAILED` + `build_status=FAILING` (no merge); per-slice halt | `state-gate-barrier.ts` |
| STORY-002 (integration) | **Live wiring** — `pipeline.ts` records each forge run's deterministic outcome to `.skillfoundry/runs/<id>/state/state.json` (advisory, try/caught — never breaks a run) | `pipeline.ts` |
| STORY-003 | **Handoff contracts** — `ajv`-backed payload validation as bus middleware; invalid dropped+logged, unregistered types pass through (FR-008) | `message-contracts.ts` |
| STORY-004 | **Capability schemas** — shared types (Severity/Finding/FileRef), permissive default registry (8 msg types), opt-in `installMessageContracts` | `message-schemas.ts` |
| STORY-005 | **Lazy language projection** — compact success summary / failure post-mortem rendered from state at the human boundary only (FR-007) | `state-projection.ts` |

## PRD mapping
- **FR-001/002/009 + §4.2/4.3** → STORY-001 (kernel)
- **FR-005/006** → STORY-002 (barrier)
- **FR-004/008** → STORY-003 (contracts)
- **OQ-3** → STORY-004 (shared types, single source)
- **FR-007** → STORY-005 (projection)

## Verification
- **47 new unit tests**, all green; every public method + error path covered
- **111 existing** bus/gate/pipeline tests still green — no regressions
- `tsc --noEmit` clean across the whole project

## Deliberate scope boundaries (not yet done — follow-ups)
- The gate barrier records the **run-level** outcome in `pipeline.ts`; **per-story slice streaming** through the story loop is a follow-up.
- Contract middleware is **opt-in** and defaults are **permissive** — it is **not** auto-installed on the global bus. Strict, flag-gated rollout with telemetry is the follow-on (per the PRD risk table).
- Per-agent capability schemas are authored as reusable shared types + a registry; **wiring strict contracts into each of the 102 agents** is incremental (FR-008).

## New dependency
- `ajv ^8.17.1` (JSON-Schema validation; named import for NodeNext).

🤖 Generated with [Claude Code](https://claude.com/claude-code)